### PR TITLE
[codex] improve static alert summaries

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       VITE_ENABLE_PWA: "false"
     ports:
       - "5173:5173"
+    volumes:
+      - ./static-site:/usr/share/nginx/html:ro
     depends_on:
       - api
 

--- a/export.sh
+++ b/export.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 OUTPUT_DIR="$SCRIPT_DIR/static-site"
+TMP_OUTPUT_DIR="$SCRIPT_DIR/static-site.next"
 
 echo "=== Sniffle Report Static Site Export ==="
 echo ""
@@ -40,10 +41,14 @@ npm run build --silent
 
 # 5. Assemble static site
 echo "[5/5] Assembling static site..."
-rm -rf "$OUTPUT_DIR"
+rm -rf "$TMP_OUTPUT_DIR"
+mkdir -p "$TMP_OUTPUT_DIR"
+cp -r dist/* "$TMP_OUTPUT_DIR/"
+cp -r "$SCRIPT_DIR/static-export/data" "$TMP_OUTPUT_DIR/data"
+
 mkdir -p "$OUTPUT_DIR"
-cp -r dist/* "$OUTPUT_DIR/"
-cp -r "$SCRIPT_DIR/static-export/data" "$OUTPUT_DIR/data"
+rsync -a --delete "$TMP_OUTPUT_DIR"/ "$OUTPUT_DIR"/
+rm -rf "$TMP_OUTPUT_DIR"
 
 TOTAL_SIZE=$(du -sh "$OUTPUT_DIR" | cut -f1)
 echo ""

--- a/src/backend/SniffleReport.Api/Models/Snapshots/SnapshotAlertSummary.cs
+++ b/src/backend/SniffleReport.Api/Models/Snapshots/SnapshotAlertSummary.cs
@@ -8,9 +8,19 @@ public sealed class SnapshotAlertSummary
 
     public string Title { get; set; } = string.Empty;
 
+    public string Summary { get; set; } = string.Empty;
+
     public string Severity { get; set; } = string.Empty;
 
     public int CaseCount { get; set; }
 
+    public string SourceAttribution { get; set; } = string.Empty;
+
     public DateTime SourceDate { get; set; }
+
+    public int? PreviousCaseCount { get; set; }
+
+    public double? WowChangePercent { get; set; }
+
+    public DateTime? PreviousSourceDate { get; set; }
 }

--- a/src/backend/SniffleReport.Api/Services/Snapshots/RegionSnapshotBuilder.cs
+++ b/src/backend/SniffleReport.Api/Services/Snapshots/RegionSnapshotBuilder.cs
@@ -107,14 +107,35 @@ public sealed class RegionSnapshotBuilder(
             .OrderByDescending(a => a.Severity)
             .ThenByDescending(a => a.SourceDate)
             .Take(config.TopAlertsCount)
-            .Select(a => new SnapshotAlertSummary
+            .Select(a =>
             {
-                AlertId = a.AlertId,
-                Disease = a.Disease,
-                Title = a.Title,
-                Severity = a.Severity.ToString(),
-                CaseCount = a.CaseCount,
-                SourceDate = a.SourceDate
+                var orderedTrendPoints = trendsByAlert.TryGetValue(a.AlertId, out var alertTrends)
+                    ? alertTrends.OrderByDescending(t => t.Date).ToList()
+                    : [];
+                var previousPoint = orderedTrendPoints.Count > 1 ? orderedTrendPoints[1] : null;
+                double? wowChangePercent = null;
+
+                if (previousPoint is not null)
+                {
+                    wowChangePercent = previousPoint.CaseCount == 0
+                        ? (a.CaseCount == 0 ? 0d : 100d)
+                        : Math.Round(((a.CaseCount - previousPoint.CaseCount) / (double)previousPoint.CaseCount) * 100d, 1);
+                }
+
+                return new SnapshotAlertSummary
+                {
+                    AlertId = a.AlertId,
+                    Disease = a.Disease,
+                    Title = a.Title,
+                    Summary = a.Summary,
+                    Severity = a.Severity.ToString(),
+                    CaseCount = a.CaseCount,
+                    SourceAttribution = a.SourceAttribution,
+                    SourceDate = a.SourceDate,
+                    PreviousCaseCount = previousPoint?.CaseCount,
+                    WowChangePercent = wowChangePercent,
+                    PreviousSourceDate = previousPoint?.Date
+                };
             })
             .ToList();
 
@@ -240,8 +261,10 @@ public sealed class RegionSnapshotBuilder(
                 RegionId = a.RegionId,
                 Disease = a.Disease,
                 Title = a.Title,
+                Summary = a.Summary,
                 Severity = a.Severity,
                 CaseCount = a.CaseCount,
+                SourceAttribution = a.SourceAttribution,
                 SourceDate = a.SourceDate
             })
             .ToListAsync(ct);
@@ -327,8 +350,10 @@ public sealed class RegionSnapshotBuilder(
         public Guid RegionId { get; init; }
         public string Disease { get; init; } = string.Empty;
         public string Title { get; init; } = string.Empty;
+        public string Summary { get; init; } = string.Empty;
         public AlertSeverity Severity { get; init; }
         public int CaseCount { get; init; }
+        public string SourceAttribution { get; init; } = string.Empty;
         public DateTime SourceDate { get; init; }
     }
 

--- a/src/backend/SniffleReport.Api/StaticExport/StaticSiteExporter.cs
+++ b/src/backend/SniffleReport.Api/StaticExport/StaticSiteExporter.cs
@@ -31,6 +31,28 @@ public sealed class StaticSiteExporter(AppDbContext dbContext, ILogger<StaticSit
             .AsNoTracking()
             .ToDictionaryAsync(s => s.RegionId, ct);
 
+        var resources = await dbContext.LocalResources
+            .AsNoTracking()
+            .Select(r => new ResourceExportData
+            {
+                Id = r.Id,
+                RegionId = r.RegionId,
+                Name = r.Name,
+                Type = r.Type.ToString(),
+                Address = r.Address,
+                Phone = r.Phone,
+                Website = r.Website
+            })
+            .ToListAsync(ct);
+
+        var resourcesByRegion = resources
+            .GroupBy(r => r.RegionId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+        var childrenByParent = regions
+            .Where(r => r.ParentId.HasValue)
+            .GroupBy(r => r.ParentId!.Value)
+            .ToDictionary(g => g.Key, g => g.Select(r => r.Id).ToList());
+
         logger.LogInformation("Loaded {RegionCount} regions and {SnapshotCount} snapshots", regions.Count, snapshots.Count);
 
         // 2. Export states.json — index of all states
@@ -113,6 +135,14 @@ public sealed class StaticSiteExporter(AppDbContext dbContext, ILogger<StaticSit
             if (!snapshots.TryGetValue(region.Id, out var snapshot))
                 continue;
 
+            var descendantIds = GetDescendantIds(region.Id, childrenByParent);
+            var nearbyResources = descendantIds
+                .SelectMany(id => resourcesByRegion.TryGetValue(id, out var items) ? items : [])
+                .OrderBy(r => GetResourceSortOrder(r.Type))
+                .ThenBy(r => r.Name)
+                .Take(6)
+                .ToList();
+
             var dashboard = new
             {
                 regionId = region.Id,
@@ -127,6 +157,7 @@ public sealed class StaticSiteExporter(AppDbContext dbContext, ILogger<StaticSit
                 topAlerts = JsonSerializer.Deserialize<List<SnapshotAlertSummary>>(snapshot.TopAlertsJson, JsonOptions) ?? [],
                 trendHighlights = JsonSerializer.Deserialize<List<SnapshotTrendHighlight>>(snapshot.TrendHighlightsJson, JsonOptions) ?? [],
                 resourceCounts = JsonSerializer.Deserialize<SnapshotResourceCounts>(snapshot.ResourceCountsJson, JsonOptions) ?? new(),
+                nearbyResources,
                 preventionHighlights = JsonSerializer.Deserialize<List<SnapshotPreventionSummary>>(snapshot.PreventionHighlightsJson, JsonOptions) ?? [],
                 newsHighlights = JsonSerializer.Deserialize<List<SnapshotNewsSummary>>(snapshot.NewsHighlightsJson, JsonOptions) ?? []
             };
@@ -210,10 +241,54 @@ public sealed class StaticSiteExporter(AppDbContext dbContext, ILogger<StaticSit
         var counts = JsonSerializer.Deserialize<SnapshotResourceCounts>(snapshot.ResourceCountsJson, JsonOptions);
         return counts?.Total ?? 0;
     }
+
+    private static HashSet<Guid> GetDescendantIds(Guid regionId, Dictionary<Guid, List<Guid>> childrenByParent)
+    {
+        var result = new HashSet<Guid> { regionId };
+        var stack = new Stack<Guid>();
+        stack.Push(regionId);
+
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            if (!childrenByParent.TryGetValue(current, out var children))
+                continue;
+
+            foreach (var child in children)
+            {
+                if (result.Add(child))
+                {
+                    stack.Push(child);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static int GetResourceSortOrder(string resourceType) => resourceType switch
+    {
+        "Pharmacy" => 0,
+        "Clinic" => 1,
+        "Hospital" => 2,
+        "VaccinationSite" => 3,
+        _ => 4
+    };
 }
 
 public sealed class ExportResult
 {
     public int FilesWritten { get; init; }
     public string OutputDirectory { get; init; } = string.Empty;
+}
+
+file sealed class ResourceExportData
+{
+    public Guid Id { get; init; }
+    public Guid RegionId { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public string Type { get; init; } = string.Empty;
+    public string Address { get; init; } = string.Empty;
+    public string? Phone { get; init; }
+    public string? Website { get; init; }
 }

--- a/src/frontend/nginx.conf
+++ b/src/frontend/nginx.conf
@@ -5,6 +5,10 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
+  location /data/ {
+    try_files $uri =404;
+  }
+
   location / {
     try_files $uri $uri/ /index.html;
   }

--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -148,6 +148,34 @@
   margin-bottom: 0.5rem;
 }
 
+.home-hero-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.home-hero-brand .brand-mark {
+  width: 4rem;
+  height: 4rem;
+}
+
+.home-hero-brand__copy {
+  display: flex;
+  flex-direction: column;
+}
+
+.home-hero-brand__copy .page-kicker {
+  margin-bottom: 0.2rem;
+}
+
+.home-hero-brand__title {
+  font-size: 1rem;
+  font-weight: 800;
+  color: var(--ink);
+  letter-spacing: -0.02em;
+}
+
 .page-hero h1 {
   font-size: clamp(1.75rem, 4vw, 2.5rem);
   font-weight: 800;
@@ -333,6 +361,42 @@
   margin: 0;
 }
 
+.dashboard-resource-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.dashboard-resource-item {
+  padding: 0.95rem 1rem;
+  background: var(--paper-deep);
+  border-radius: var(--radius-md);
+}
+
+.dashboard-resource-item__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.dashboard-resource-item__header strong {
+  font-size: 0.9375rem;
+}
+
+.dashboard-resource-item p {
+  margin: 0 0 0.45rem;
+  color: var(--ink-soft);
+}
+
+.dashboard-resource-item__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
 /* ── Alert Cards (Dashboard) ──────────────────────── */
 
 .dashboard-alert-list {
@@ -370,10 +434,29 @@
   color: var(--ink-soft);
 }
 
+.dashboard-alert-card__updates {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
 .dashboard-alert-card strong {
   font-size: 0.875rem;
   font-weight: 600;
   line-height: 1.3;
+}
+
+.dashboard-alert-card__summary {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  color: var(--ink-soft);
+}
+
+.dashboard-alert-card__trend {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--ink);
 }
 
 .dashboard-alert-card__meta {
@@ -668,12 +751,101 @@
   font-variant-numeric: tabular-nums;
 }
 
+.state-region-row--with-alerts {
+  background:
+    linear-gradient(90deg, rgba(254, 215, 170, 0.4), rgba(255, 247, 237, 0.2));
+}
+
+.state-region-row--with-alerts td:first-child {
+  box-shadow: inset 4px 0 0 var(--accent);
+}
+
 .status-table--regions tbody tr:hover {
   background: var(--paper-deep);
 }
 
 .status-table--regions td a {
   font-weight: 500;
+}
+
+.state-alert-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: var(--danger-bg);
+  color: var(--danger);
+  font-size: 0.75rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.state-alert-pill--quiet {
+  background: var(--paper-deep);
+  color: var(--ink-faint);
+  font-weight: 600;
+}
+
+.statewide-pattern-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.875rem;
+}
+
+.statewide-pattern-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  background: var(--paper-deep);
+}
+
+.statewide-pattern-card__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.statewide-pattern-card p {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: var(--ink-soft);
+}
+
+.statewide-pattern-card__stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.statewide-pattern-card__examples {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.statewide-pattern-card__example {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.28rem 0.55rem;
+  border-radius: 999px;
+  background: #fff3e8;
+  color: #9a3412;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.statewide-pattern-card__example--more {
+  background: var(--paper);
+  color: var(--ink-soft);
+}
+
+.statewide-pattern-card__meta {
+  font-size: 0.75rem;
+  color: var(--ink-faint);
 }
 
 .status-badge {
@@ -808,6 +980,20 @@
 
   .page-hero {
     padding: 1.5rem 0 1rem;
+  }
+
+  .home-hero-brand {
+    gap: 0.75rem;
+    margin-bottom: 0.85rem;
+  }
+
+  .home-hero-brand .brand-mark {
+    width: 3.25rem;
+    height: 3.25rem;
+  }
+
+  .home-hero-brand__title {
+    font-size: 0.9375rem;
   }
 
   .dashboard-grid {

--- a/src/frontend/src/api/types.ts
+++ b/src/frontend/src/api/types.ts
@@ -383,9 +383,14 @@ export const snapshotAlertSummarySchema = z.object({
   alertId: guidSchema,
   disease: z.string().min(1),
   title: z.string().min(1),
+  summary: z.string(),
   severity: z.string().min(1),
   caseCount: z.number().int().nonnegative(),
+  sourceAttribution: z.string(),
   sourceDate: isoDateTimeSchema,
+  previousCaseCount: z.number().int().nonnegative().nullable().optional(),
+  wowChangePercent: z.number().nullable().optional(),
+  previousSourceDate: isoDateTimeSchema.nullable().optional(),
 })
 
 export const snapshotTrendHighlightSchema = z.object({

--- a/src/frontend/src/hooks/useStaticData.ts
+++ b/src/frontend/src/hooks/useStaticData.ts
@@ -8,6 +8,7 @@ import {
   snapshotResourceCountsSchema,
   snapshotPreventionSummarySchema,
   snapshotNewsSummarySchema,
+  resourceTypeSchema,
 } from '../api/types'
 
 // --- State index schema ---
@@ -69,6 +70,17 @@ const staticDashboardSchema = z.object({
   topAlerts: z.array(snapshotAlertSummarySchema),
   trendHighlights: z.array(snapshotTrendHighlightSchema),
   resourceCounts: snapshotResourceCountsSchema,
+  nearbyResources: z.array(
+    z.object({
+      id: z.string().uuid(),
+      regionId: z.string().uuid(),
+      name: z.string().min(1),
+      type: resourceTypeSchema,
+      address: z.string().min(1),
+      phone: z.string().nullable(),
+      website: z.string().nullable(),
+    }),
+  ),
   preventionHighlights: z.array(snapshotPreventionSummarySchema),
   newsHighlights: z.array(snapshotNewsSummarySchema),
 })

--- a/src/frontend/src/pages/HomePage.tsx
+++ b/src/frontend/src/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 
+import { SniffleReportLogo } from '../components/layout/SniffleReportLogo'
 import { useStates } from '../hooks/useStaticData'
 import { validateAndSanitizeUrl } from '../utils/validateAndSanitizeUrl'
 
@@ -11,7 +12,13 @@ export function HomePage() {
     <section className="page-frame">
       <div className="page-stack">
         <article className="page-hero">
-          <span className="page-kicker">Sniffle Report</span>
+          <div className="home-hero-brand">
+            <SniffleReportLogo />
+            <div className="home-hero-brand__copy">
+              <span className="page-kicker">Sniffle Report</span>
+              <span className="home-hero-brand__title">Regional health intelligence</span>
+            </div>
+          </div>
           <h1>Community health data for every US county</h1>
           <p>
             Regional health trends, disease surveillance, local clinics and pharmacies,

--- a/src/frontend/src/pages/RegionalDashboardPage.test.tsx
+++ b/src/frontend/src/pages/RegionalDashboardPage.test.tsx
@@ -21,16 +21,33 @@ vi.mock('../hooks/useStaticData', () => ({
           alertId: '1f1ecb6b-c7dc-4142-bdc7-bff8cb6c57e4',
           disease: 'Influenza A',
           title: 'Seasonal flu activity is elevated',
+          summary: 'Emergency department visits and lab-confirmed cases are increasing across the county.',
           severity: 'High',
           caseCount: 123,
+          sourceAttribution: 'County health department surveillance',
           sourceDate: '2026-03-20T00:00:00Z',
+          previousCaseCount: 77,
+          wowChangePercent: 59.7,
+          previousSourceDate: '2026-03-13T00:00:00Z',
+        },
+        {
+          alertId: '951bfbd1-3074-44ed-a753-7273c8105e2f',
+          disease: 'Influenza A',
+          title: 'Seasonal flu activity is elevated',
+          summary: 'Emergency department visits and lab-confirmed cases are increasing across the county.',
+          severity: 'High',
+          caseCount: 123,
+          sourceAttribution: 'County health department surveillance',
+          sourceDate: '2026-03-19T00:00:00Z',
         },
         {
           alertId: 'cdf50eb8-cf20-4322-aa52-6e42c342f30d',
           disease: 'RSV',
           title: 'Pediatric RSV remains active',
+          summary: 'RSV activity remains elevated for young children and urgent care visits are up.',
           severity: 'Moderate',
           caseCount: 58,
+          sourceAttribution: 'Regional pediatric hospital network',
           sourceDate: '2026-03-18T00:00:00Z',
         },
       ],
@@ -51,6 +68,17 @@ vi.mock('../hooks/useStaticData', () => ({
         hospital: 1,
         total: 24,
       },
+      nearbyResources: [
+        {
+          id: '917cc0d1-9ea0-4f11-b0bb-0f1894b60f1f',
+          regionId: '8fb8cb1d-6622-4c13-a0b8-f6ccebc5454b',
+          name: 'Travis Pharmacy',
+          type: 'Pharmacy',
+          address: '123 Congress Ave, Austin, TX',
+          phone: '(512) 555-0110',
+          website: 'https://example.org/pharmacy',
+        },
+      ],
       preventionHighlights: [
         {
           guideId: 'b7e9c781-13fe-4a0e-bb73-c5f3d063a213',
@@ -81,12 +109,20 @@ describe('RegionalDashboardPage', () => {
     )
 
     expect(screen.getByRole('heading', { name: 'Travis County, TX' })).toBeInTheDocument()
-    expect(screen.getByText(/12 clinics/i)).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /all alerts/i })).toHaveAttribute(
+    expect(screen.getByText(/travis pharmacy/i)).toBeInTheDocument()
+    expect(screen.getByText(/123 congress ave, austin, tx/i)).toBeInTheDocument()
+    expect(screen.getByText(/this page is the complete published view for this region/i)).toBeInTheDocument()
+    expect(screen.getByText(/emergency department visits and lab-confirmed cases are increasing/i)).toBeInTheDocument()
+    expect(screen.getByText(/county health department surveillance/i)).toBeInTheDocument()
+    expect(screen.getByText(/77 previous cases · \+59.7% WoW/i)).toBeInTheDocument()
+    expect(screen.getByText(/2 updates/i)).toBeInTheDocument()
+    expect(screen.getByText(/county health department surveillance · mar 18-20, 2026/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /back to texas/i })).toHaveAttribute(
       'href',
-      '/region/8fb8cb1d-6622-4c13-a0b8-f6ccebc5454b/alerts',
+      '/states/TX',
     )
     expect(screen.getByText(/seasonal flu activity is elevated/i)).toBeInTheDocument()
-    expect(screen.getByText(/59.7% WoW/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/seasonal flu activity is elevated/i)).toHaveLength(1)
+    expect(screen.getByText(/123 cases \(\+59.7% WoW\)/i)).toBeInTheDocument()
   })
 })

--- a/src/frontend/src/pages/RegionalDashboardPage.tsx
+++ b/src/frontend/src/pages/RegionalDashboardPage.tsx
@@ -1,6 +1,6 @@
 import { Link, useParams } from 'react-router-dom'
 
-import type { SnapshotTrendHighlight } from '../api/types'
+import type { RegionDashboard, SnapshotTrendHighlight } from '../api/types'
 import { FactCheckBadge } from '../components/news/FactCheckBadge'
 import { SeverityBadge } from '../components/dashboard/SeverityBadge'
 import { useStaticDashboard } from '../hooks/useStaticData'
@@ -21,13 +21,144 @@ function formatDate(date: string) {
   }).format(new Date(date))
 }
 
+function formatDateRange(startDate: string, endDate: string) {
+  const start = new Date(startDate)
+  const end = new Date(endDate)
+  const sameYear = start.getUTCFullYear() === end.getUTCFullYear()
+  const sameMonth = sameYear && start.getUTCMonth() === end.getUTCMonth()
+
+  if (sameMonth) {
+    return new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: 'numeric',
+    }).format(start) + `-${end.getUTCDate()}, ${end.getUTCFullYear()}`
+  }
+
+  if (sameYear) {
+    return `${new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: 'numeric',
+    }).format(start)}-${new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: 'numeric',
+    }).format(end)}, ${end.getUTCFullYear()}`
+  }
+
+  return `${formatDate(startDate)}-${formatDate(endDate)}`
+}
+
 function formatWowChange(highlight: SnapshotTrendHighlight) {
   const sign = highlight.wowChangePercent >= 0 ? '+' : ''
   return `${sign}${highlight.wowChangePercent.toFixed(1)}%`
 }
 
-function buildRegionPath(regionId: string, segment?: string) {
-  return segment ? `/region/${regionId}/${segment}` : `/region/${regionId}`
+function formatAlertWowChange(wowChangePercent: number) {
+  const sign = wowChangePercent >= 0 ? '+' : ''
+  return `${sign}${wowChangePercent.toFixed(1)}%`
+}
+
+function buildAlertSummary(alert: {
+  summary: string
+  caseCount: number
+  disease: string
+  severity: string
+}) {
+  if (alert.summary.trim()) {
+    return alert.summary
+  }
+
+  return `${alert.caseCount} reported case${alert.caseCount === 1 ? '' : 's'} for ${alert.disease}. Severity is ${alert.severity.toLowerCase()}.`
+}
+
+function getSafeTelLink(phone: string | null) {
+  if (!phone) {
+    return null
+  }
+
+  const sanitized = phone.replace(/[^\d+]/g, '')
+  return sanitized ? validateAndSanitizeUrl(`tel:${sanitized}`) : null
+}
+
+type DashboardAlert = RegionDashboard['topAlerts'][number]
+
+type DisplayAlert = DashboardAlert & {
+  latestSourceDate: string
+  earliestSourceDate: string
+  occurrenceCount: number
+}
+
+function createAlertGroupKey(alert: DashboardAlert) {
+  return [
+    alert.disease.trim().toLowerCase(),
+    alert.title.trim().toLowerCase(),
+    alert.summary.trim().toLowerCase(),
+    alert.severity.trim().toLowerCase(),
+    alert.caseCount,
+    alert.sourceAttribution.trim().toLowerCase(),
+  ].join('::')
+}
+
+function dedupeAlerts(alerts: DashboardAlert[]) {
+  const groupedAlerts = new Map<string, DisplayAlert>()
+
+  alerts.forEach((alert) => {
+    const key = createAlertGroupKey(alert)
+    const existing = groupedAlerts.get(key)
+
+    if (!existing) {
+      groupedAlerts.set(key, {
+        ...alert,
+        latestSourceDate: alert.sourceDate,
+        earliestSourceDate: alert.sourceDate,
+        occurrenceCount: 1,
+      })
+      return
+    }
+
+    const sourceTime = new Date(alert.sourceDate).getTime()
+    const latestTime = new Date(existing.latestSourceDate).getTime()
+    const earliestTime = new Date(existing.earliestSourceDate).getTime()
+
+    existing.occurrenceCount += 1
+
+    if (sourceTime > latestTime) {
+      existing.latestSourceDate = alert.sourceDate
+      existing.sourceDate = alert.sourceDate
+      existing.alertId = alert.alertId
+      existing.previousCaseCount = alert.previousCaseCount
+      existing.wowChangePercent = alert.wowChangePercent
+      existing.previousSourceDate = alert.previousSourceDate
+    }
+
+    if (sourceTime < earliestTime) {
+      existing.earliestSourceDate = alert.sourceDate
+    }
+  })
+
+  return [...groupedAlerts.values()]
+}
+
+function buildAlertDateLabel(alert: DisplayAlert) {
+  if (alert.occurrenceCount <= 1) {
+    return formatDate(alert.latestSourceDate)
+  }
+
+  return formatDateRange(alert.earliestSourceDate, alert.latestSourceDate)
+}
+
+function buildAlertOccurrencesLabel(alert: DisplayAlert) {
+  if (alert.occurrenceCount <= 1) {
+    return null
+  }
+
+  return `${alert.occurrenceCount} updates`
+}
+
+function buildDisplayAlertMeta(alert: DisplayAlert) {
+  const dateLabel = buildAlertDateLabel(alert)
+  const sourceLabel = alert.sourceAttribution.trim() ? alert.sourceAttribution : 'Snapshot date'
+
+  return `${sourceLabel} · ${dateLabel}`
 }
 
 export function RegionalDashboardPage() {
@@ -44,10 +175,12 @@ export function RegionalDashboardPage() {
   const isLoading = dashboardQuery.isLoading
   const hasError = dashboardQuery.isError
 
-  const topAlerts = [...(dashboard?.topAlerts ?? [])]
+  const topAlerts = dedupeAlerts([...(dashboard?.topAlerts ?? [])])
     .sort((left, right) => {
       const severityDiff = (severityRank[right.severity] ?? 0) - (severityRank[left.severity] ?? 0)
       if (severityDiff !== 0) return severityDiff
+      const occurrenceDiff = right.occurrenceCount - left.occurrenceCount
+      if (occurrenceDiff !== 0) return occurrenceDiff
       return right.caseCount - left.caseCount
     })
     .slice(0, 5)
@@ -57,6 +190,7 @@ export function RegionalDashboardPage() {
     .slice(0, 3)
 
   const resourceCounts = dashboard?.resourceCounts
+  const nearbyResources = dashboard?.nearbyResources ?? []
   const resourceParts = resourceCounts
     ? [
         resourceCounts.clinic > 0 ? `${resourceCounts.clinic} clinics` : null,
@@ -68,13 +202,6 @@ export function RegionalDashboardPage() {
   const resourceSummary = resourceParts.length > 0
     ? resourceParts.join(', ')
     : 'No local resources indexed'
-
-  const dashboardLinks = [
-    { label: 'All alerts', segment: 'alerts' },
-    { label: 'Prevention guides', segment: 'prevention' },
-    { label: 'Resources', segment: 'resources' },
-    { label: 'Health news', segment: 'news' },
-  ]
 
   return (
     <section className="page-frame">
@@ -135,10 +262,19 @@ export function RegionalDashboardPage() {
                     <div className="dashboard-alert-card__row">
                       <SeverityBadge severity={alert.severity as 'Low' | 'Moderate' | 'High' | 'Critical'} />
                       <span className="dashboard-alert-card__cases">{alert.caseCount} cases</span>
+                      {buildAlertOccurrencesLabel(alert) ? (
+                        <span className="dashboard-alert-card__updates">{buildAlertOccurrencesLabel(alert)}</span>
+                      ) : null}
                     </div>
                     <strong>{alert.title}</strong>
+                    <p className="dashboard-alert-card__summary">{buildAlertSummary(alert)}</p>
+                    {alert.previousCaseCount != null && alert.wowChangePercent != null ? (
+                      <span className="dashboard-alert-card__trend">
+                        {alert.previousCaseCount} previous cases · {formatAlertWowChange(alert.wowChangePercent)} WoW
+                      </span>
+                    ) : null}
                     <span className="dashboard-alert-card__meta">
-                      {alert.disease} · {formatDate(alert.sourceDate)}
+                      {buildDisplayAlertMeta(alert)}
                     </span>
                   </article>
                 ))}
@@ -242,7 +378,7 @@ export function RegionalDashboardPage() {
             <div className="dashboard-card__header">
               <div>
                 <span className="section-kicker">Local access</span>
-                <strong>Nearby healthcare resources</strong>
+                <strong>Indexed healthcare resources</strong>
               </div>
             </div>
 
@@ -250,6 +386,33 @@ export function RegionalDashboardPage() {
               <div className="dashboard-skeleton-group" aria-hidden="true">
                 <div className="dashboard-skeleton dashboard-skeleton--line" />
                 <div className="dashboard-skeleton dashboard-skeleton--card" />
+              </div>
+            ) : nearbyResources.length ? (
+              <div className="dashboard-resource-list">
+                {nearbyResources.map((resource) => {
+                  const websiteHref = resource.website
+                    ? validateAndSanitizeUrl(resource.website)
+                    : null
+                  const phoneHref = getSafeTelLink(resource.phone)
+
+                  return (
+                    <article className="dashboard-resource-item" key={resource.id}>
+                      <div className="dashboard-resource-item__header">
+                        <strong>{resource.name}</strong>
+                        <span className="page-badge">{resource.type}</span>
+                      </div>
+                      <p>{resource.address}</p>
+                      <div className="dashboard-resource-item__links">
+                        {websiteHref && websiteHref !== '/' ? (
+                          <a href={websiteHref} rel="noreferrer" target="_blank">
+                            Website
+                          </a>
+                        ) : null}
+                        {phoneHref && phoneHref !== '/' ? <a href={phoneHref}>{resource.phone}</a> : null}
+                      </div>
+                    </article>
+                  )
+                })}
               </div>
             ) : (
               <div className="dashboard-resource-summary">
@@ -263,18 +426,28 @@ export function RegionalDashboardPage() {
         </div>
 
         <section className="page-panel dashboard-nav-panel">
-          <span className="section-kicker">Explore this region</span>
-          <strong>Jump deeper into the region-scoped views.</strong>
-          <div className="dashboard-nav-links">
-            {dashboardLinks.map((item) => (
+          <span className="section-kicker">Static snapshot</span>
+          <strong>This page is the complete published view for this region.</strong>
+          <p className="dashboard-empty">
+            Detailed subpages for alerts, prevention, resources, and news were part of the old
+            dynamic UI and are not included in the static site.
+          </p>
+          <div className="page-badges">
+            <span className="page-badge">
+              Exported {dashboard?.computedAt ? formatDate(dashboard.computedAt) : 'with the latest snapshot'}
+            </span>
+            {dashboard?.parentState ? (
               <Link
-                className="dashboard-nav-link"
-                key={item.segment}
-                to={validateAndSanitizeUrl(buildRegionPath(regionId ?? '', item.segment))}
+                className="page-badge page-badge--link"
+                to={validateAndSanitizeUrl(`/states/${dashboard.parentState}`)}
               >
-                {item.label}
+                Back to {dashboard.parentName}
               </Link>
-            ))}
+            ) : (
+              <Link className="page-badge page-badge--link" to={validateAndSanitizeUrl('/')}>
+                Back to home
+              </Link>
+            )}
           </div>
         </section>
       </div>

--- a/src/frontend/src/pages/StateBrowsePage.test.tsx
+++ b/src/frontend/src/pages/StateBrowsePage.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+
+import { StateBrowsePage } from './StateBrowsePage'
+
+vi.mock('../hooks/useStaticData', () => ({
+  useStateDetail: () => ({
+    data: {
+      id: '21d21acc-ea72-4015-afd4-f8415f09736d',
+      name: 'Pennsylvania',
+      code: 'PA',
+      publishedAlertCount: 179,
+      resourceTotal: 638,
+      computedAt: '2026-04-05T21:45:20.061451Z',
+      counties: [
+        {
+          id: '4156a173-433d-4823-b48a-deb80c0842fa',
+          name: 'Chester County',
+          type: 'County',
+          state: 'PA',
+          latitude: 39.973965,
+          longitude: -75.749732,
+          publishedAlertCount: 5,
+          resourceTotal: 27,
+          computedAt: '2026-04-05T21:45:20.061451Z',
+        },
+        {
+          id: '934eeba8-0214-408e-a386-39cae7869459',
+          name: 'Adams County',
+          type: 'County',
+          state: 'PA',
+          latitude: 39.869471,
+          longitude: -77.21773,
+          publishedAlertCount: 0,
+          resourceTotal: 3,
+          computedAt: '2026-04-05T21:45:20.061451Z',
+        },
+      ],
+    },
+    isLoading: false,
+  }),
+  useStaticDashboard: () => ({
+    data: {
+      regionId: '21d21acc-ea72-4015-afd4-f8415f09736d',
+      regionName: 'Pennsylvania',
+      regionType: 'State',
+      state: 'PA',
+      parentName: null,
+      parentId: null,
+      parentState: null,
+      computedAt: '2026-04-05T21:45:20.061451Z',
+      publishedAlertCount: 179,
+      topAlerts: [
+        {
+          alertId: 'a9e6d0ce-f25c-43d3-8fb7-290bced9595d',
+          disease: 'Hepatitis C, chronic, Probable',
+          title: 'Hepatitis C, chronic, Probable — data from CDC NNDSS Weekly Tables',
+          summary: 'Surveillance data ingested from CDC NNDSS Weekly Tables.',
+          severity: 'Low',
+          caseCount: 0,
+          sourceAttribution: 'CDC NNDSS Weekly Tables',
+          sourceDate: '2026-04-04T18:03:43.313683Z',
+          previousCaseCount: null,
+          wowChangePercent: null,
+          previousSourceDate: null,
+        },
+        {
+          alertId: 'afcb0711-fe36-4777-87e4-088f59debd80',
+          disease: 'Hepatitis C, perinatal, Confirmed',
+          title: 'Hepatitis C, perinatal, Confirmed — data from CDC NNDSS Weekly Tables',
+          summary: 'Surveillance data ingested from CDC NNDSS Weekly Tables.',
+          severity: 'Low',
+          caseCount: 0,
+          sourceAttribution: 'CDC NNDSS Weekly Tables',
+          sourceDate: '2026-04-04T18:03:43.300343Z',
+          previousCaseCount: null,
+          wowChangePercent: null,
+          previousSourceDate: null,
+        },
+        {
+          alertId: '7578ca9c-c677-468f-bbe3-ced82fb2ef59',
+          disease: 'Influenza-associated pediatric mortality',
+          title: 'Influenza-associated pediatric mortality — data from CDC NNDSS Weekly Tables',
+          summary: 'Surveillance data ingested from CDC NNDSS Weekly Tables.',
+          severity: 'Low',
+          caseCount: 0,
+          sourceAttribution: 'CDC NNDSS Weekly Tables',
+          sourceDate: '2026-04-04T18:03:43.287101Z',
+          previousCaseCount: null,
+          wowChangePercent: null,
+          previousSourceDate: null,
+        },
+      ],
+      trendHighlights: [],
+      resourceCounts: {
+        clinic: 231,
+        pharmacy: 202,
+        vaccinationSite: 0,
+        hospital: 205,
+        total: 638,
+      },
+      nearbyResources: [],
+      preventionHighlights: [],
+      newsHighlights: [],
+    },
+  }),
+}))
+
+describe('StateBrowsePage', () => {
+  it('groups repeated statewide alert feeds into a summary section', () => {
+    const queryClient = new QueryClient()
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/states/PA']}>
+          <Routes>
+            <Route path="/states/:stateCode" element={<StateBrowsePage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    expect(screen.getByRole('heading', { name: /counties in pennsylvania/i })).toBeInTheDocument()
+    expect(screen.getByText(/grouped signals from repeated statewide feeds/i)).toBeInTheDocument()
+    expect(screen.getByText(/cdc nndss weekly tables/i)).toBeInTheDocument()
+    expect(screen.getByText(/3 notices/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/3 diseases/i)).toHaveLength(2)
+    expect(screen.getByText(/surveillance-only/i)).toBeInTheDocument()
+    expect(screen.getByText(/this feed contributes 3 statewide notices across 3 diseases/i)).toBeInTheDocument()
+    expect(screen.getByText(/hepatitis c, chronic, probable/i)).toBeInTheDocument()
+    expect(screen.getByText(/hepatitis c, perinatal, confirmed/i)).toBeInTheDocument()
+    expect(screen.getByText(/influenza-associated pediatric mortality/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /chester county/i })).toHaveAttribute('href', '/region/4156a173-433d-4823-b48a-deb80c0842fa')
+  })
+})

--- a/src/frontend/src/pages/StateBrowsePage.tsx
+++ b/src/frontend/src/pages/StateBrowsePage.tsx
@@ -1,7 +1,9 @@
 import { useMemo, useState } from 'react'
 import { Link, Navigate, useParams } from 'react-router-dom'
 
-import { useStateDetail } from '../hooks/useStaticData'
+import type { RegionDashboard } from '../api/types'
+import { SeverityBadge } from '../components/dashboard/SeverityBadge'
+import { useStateDetail, useStaticDashboard } from '../hooks/useStaticData'
 import { validateAndSanitizeUrl } from '../utils/validateAndSanitizeUrl'
 
 type SortKey = 'name' | 'publishedAlertCount' | 'resourceTotal'
@@ -16,10 +18,89 @@ function formatRelative(date: string | null) {
   return `${Math.floor(hours / 24)}d ago`
 }
 
+function formatDate(date: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(new Date(date))
+}
+
+type StatewidePattern = {
+  key: string
+  sourceAttribution: string
+  severity: string
+  alertCount: number
+  diseaseCount: number
+  maxCaseCount: number
+  latestDate: string
+  diseases: string[]
+}
+
+function groupStatewideAlerts(topAlerts: RegionDashboard['topAlerts']) {
+  const patterns = new Map<string, StatewidePattern>()
+
+  topAlerts.forEach((alert) => {
+    const key = `${alert.sourceAttribution.trim().toLowerCase()}::${alert.severity.trim().toLowerCase()}`
+    const existing = patterns.get(key)
+
+    if (!existing) {
+      patterns.set(key, {
+        key,
+        sourceAttribution: alert.sourceAttribution || 'Snapshot feed',
+        severity: alert.severity,
+        alertCount: 1,
+        diseaseCount: 1,
+        maxCaseCount: alert.caseCount,
+        latestDate: alert.sourceDate,
+        diseases: [alert.disease],
+      })
+      return
+    }
+
+    existing.alertCount += 1
+    existing.maxCaseCount = Math.max(existing.maxCaseCount, alert.caseCount)
+
+    if (new Date(alert.sourceDate).getTime() > new Date(existing.latestDate).getTime()) {
+      existing.latestDate = alert.sourceDate
+    }
+
+    if (!existing.diseases.includes(alert.disease)) {
+      existing.diseases.push(alert.disease)
+      existing.diseaseCount = existing.diseases.length
+    }
+  })
+
+  return [...patterns.values()]
+    .sort((left, right) => {
+      if (right.alertCount !== left.alertCount) return right.alertCount - left.alertCount
+      if (right.maxCaseCount !== left.maxCaseCount) return right.maxCaseCount - left.maxCaseCount
+      return new Date(right.latestDate).getTime() - new Date(left.latestDate).getTime()
+    })
+    .slice(0, 3)
+}
+
+function buildPatternSummary(pattern: StatewidePattern) {
+  if (pattern.maxCaseCount > 0) {
+    return `This feed contributes ${pattern.alertCount} statewide notices across ${pattern.diseaseCount} diseases. Highest reported count in this group is ${pattern.maxCaseCount} cases.`
+  }
+
+  return `This feed contributes ${pattern.alertCount} statewide notices across ${pattern.diseaseCount} diseases. These are surveillance notices in the current statewide snapshot.`
+}
+
+function buildPatternExamples(pattern: StatewidePattern) {
+  return pattern.diseases.slice(0, 4)
+}
+
+function buildPatternExamplesRemainder(pattern: StatewidePattern) {
+  return pattern.diseaseCount - buildPatternExamples(pattern).length
+}
+
 export function StateBrowsePage() {
   const { stateCode } = useParams<{ stateCode: string }>()
   const stateQuery = useStateDetail(stateCode ?? '')
   const state = stateQuery.data
+  const stateDashboardQuery = useStaticDashboard(state?.id ?? '')
 
   const [sortKey, setSortKey] = useState<SortKey>('name')
   const [sortDir, setSortDir] = useState<SortDirection>('asc')
@@ -37,6 +118,11 @@ export function StateBrowsePage() {
       return sortDir === 'asc' ? cmp : -cmp
     })
   }, [state, sortKey, sortDir])
+
+  const statewidePatterns = useMemo(() => {
+    if (!stateDashboardQuery.data) return []
+    return groupStatewideAlerts(stateDashboardQuery.data.topAlerts)
+  }, [stateDashboardQuery.data])
 
   function toggleSort(key: SortKey) {
     if (sortKey === key) {
@@ -109,6 +195,52 @@ export function StateBrowsePage() {
           </div>
         </article>
 
+        {statewidePatterns.length ? (
+          <section className="page-panel">
+            <div className="dashboard-card__header">
+              <div>
+                <span className="section-kicker">Statewide alert patterns</span>
+                <strong>Grouped signals from repeated statewide feeds</strong>
+              </div>
+            </div>
+            <div className="statewide-pattern-list">
+              {statewidePatterns.map((pattern) => (
+                <article className="statewide-pattern-card" key={pattern.key}>
+                  <div className="statewide-pattern-card__header">
+                    <SeverityBadge severity={pattern.severity as 'Low' | 'Moderate' | 'High' | 'Critical'} />
+                    <span className="state-alert-pill">
+                      {pattern.alertCount} notice{pattern.alertCount === 1 ? '' : 's'}
+                    </span>
+                  </div>
+                  <strong>{pattern.sourceAttribution}</strong>
+                  <div className="statewide-pattern-card__stats">
+                    <span className="page-badge">{pattern.diseaseCount} diseases</span>
+                    {pattern.maxCaseCount > 0 ? (
+                      <span className="page-badge">{pattern.maxCaseCount} max cases</span>
+                    ) : (
+                      <span className="page-badge">Surveillance-only</span>
+                    )}
+                  </div>
+                  <p>{buildPatternSummary(pattern)}</p>
+                  <div className="statewide-pattern-card__examples">
+                    {buildPatternExamples(pattern).map((disease) => (
+                      <span className="statewide-pattern-card__example" key={disease}>{disease}</span>
+                    ))}
+                    {buildPatternExamplesRemainder(pattern) > 0 ? (
+                      <span className="statewide-pattern-card__example statewide-pattern-card__example--more">
+                        +{buildPatternExamplesRemainder(pattern)} more
+                      </span>
+                    ) : null}
+                  </div>
+                  <span className="statewide-pattern-card__meta">
+                    Updated {formatDate(pattern.latestDate)}
+                  </span>
+                </article>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
         <section className="page-panel">
           <div className="status-table-wrap">
             <table className="status-table status-table--regions">
@@ -128,13 +260,28 @@ export function StateBrowsePage() {
               </thead>
               <tbody>
                 {counties.map((county) => (
-                  <tr key={county.id}>
+                  <tr
+                    className={
+                      county.publishedAlertCount > 0
+                        ? 'state-region-row state-region-row--with-alerts'
+                        : 'state-region-row'
+                    }
+                    key={county.id}
+                  >
                     <td>
                       <Link to={validateAndSanitizeUrl(`/region/${county.id}`)}>
                         {county.name}
                       </Link>
                     </td>
-                    <td>{county.publishedAlertCount}</td>
+                    <td>
+                      {county.publishedAlertCount > 0 ? (
+                        <span className="state-alert-pill">
+                          {county.publishedAlertCount} alert{county.publishedAlertCount === 1 ? '' : 's'}
+                        </span>
+                      ) : (
+                        <span className="state-alert-pill state-alert-pill--quiet">0 alerts</span>
+                      )}
+                    </td>
                     <td>{county.resourceTotal}</td>
                     <td>{formatRelative(county.computedAt)}</td>
                   </tr>


### PR DESCRIPTION
## What changed
- improved static region alert cards with deduped repeated alerts, clearer summaries, and optional trend context
- added grouped statewide alert-pattern summaries above state county tables
- updated the static export and local preview plumbing so the static site serves the built data correctly
- improved local access cards to show concrete nearby resources and added homepage logo rendering

## Why
The static UI still had leftover noisy alert presentation and some local preview/export issues. These changes make the static pages read like intentional summaries instead of raw feed dumps.

## Validation
- npm test -- --run RegionalDashboardPage.test.tsx
- npm test -- --run StateBrowsePage.test.tsx
- npm run build
- bash export.sh