### PR TITLE
[codex] add phase 1 access and safety data

### DIFF
--- a/src/backend/SniffleReport.Api/Controllers/ExportController.cs
+++ b/src/backend/SniffleReport.Api/Controllers/ExportController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using SniffleReport.Api.Services.Snapshots;
 using SniffleReport.Api.StaticExport;
 
 namespace SniffleReport.Api.Controllers;
@@ -7,11 +8,15 @@ namespace SniffleReport.Api.Controllers;
 [ApiController]
 [AllowAnonymous]
 [Route("api/v1/export")]
-public sealed class ExportController(StaticSiteExporter exporter) : ControllerBase
+public sealed class ExportController(
+    StaticSiteExporter exporter,
+    RegionSnapshotBuilder snapshotBuilder) : ControllerBase
 {
     [HttpPost("static")]
     public async Task<ActionResult<ExportResult>> ExportStatic(CancellationToken cancellationToken)
     {
+        await snapshotBuilder.RebuildAllAsync(cancellationToken);
+
         var outputDir = Path.GetFullPath(Path.Combine(
             AppContext.BaseDirectory, "..", "..", "..", "..", "..", "static-export", "data"));
 

--- a/src/backend/SniffleReport.Api/Controllers/Public/DashboardController.cs
+++ b/src/backend/SniffleReport.Api/Controllers/Public/DashboardController.cs
@@ -47,6 +47,8 @@ public sealed class DashboardController(
             TopAlerts = JsonSerializer.Deserialize<List<SnapshotAlertSummary>>(snapshot.TopAlertsJson, JsonOptions) ?? [],
             TrendHighlights = JsonSerializer.Deserialize<List<SnapshotTrendHighlight>>(snapshot.TrendHighlightsJson, JsonOptions) ?? [],
             ResourceCounts = JsonSerializer.Deserialize<SnapshotResourceCounts>(snapshot.ResourceCountsJson, JsonOptions) ?? new(),
+            AccessSignals = JsonSerializer.Deserialize<List<SnapshotAccessSignalSummary>>(snapshot.AccessSignalsJson, JsonOptions) ?? [],
+            EnvironmentalSignals = JsonSerializer.Deserialize<List<SnapshotEnvironmentalSignalSummary>>(snapshot.EnvironmentalSignalsJson, JsonOptions) ?? [],
             PreventionHighlights = JsonSerializer.Deserialize<List<SnapshotPreventionSummary>>(snapshot.PreventionHighlightsJson, JsonOptions) ?? [],
             NewsHighlights = JsonSerializer.Deserialize<List<SnapshotNewsSummary>>(snapshot.NewsHighlightsJson, JsonOptions) ?? []
         };

--- a/src/backend/SniffleReport.Api/Controllers/Public/StatusController.cs
+++ b/src/backend/SniffleReport.Api/Controllers/Public/StatusController.cs
@@ -76,10 +76,20 @@ public sealed class StatusController(AppDbContext dbContext) : ControllerBase
             .GroupBy(log => log.FeedSourceId)
             .Select(g => g.OrderByDescending(log => log.StartedAt).First())
             .ToDictionaryAsync(log => log.FeedSourceId, cancellationToken);
+        var latestIngests = await dbContext.IngestedRecords
+            .AsNoTracking()
+            .GroupBy(record => record.FeedSourceId)
+            .Select(g => new
+            {
+                FeedSourceId = g.Key,
+                LastIngestedAt = g.Max(record => record.LastIngestedAt)
+            })
+            .ToDictionaryAsync(x => x.FeedSourceId, x => (DateTime?)x.LastIngestedAt, cancellationToken);
 
         var result = feeds.Select(feed =>
         {
             latestSyncs.TryGetValue(feed.Id, out var lastSync);
+            latestIngests.TryGetValue(feed.Id, out var lastIngestedAt);
 
             return new FeedStatusDto
             {
@@ -88,7 +98,7 @@ public sealed class StatusController(AppDbContext dbContext) : ControllerBase
                 Type = feed.Type.ToString(),
                 IsEnabled = feed.IsEnabled,
                 LastSyncStatus = feed.LastSyncStatus.ToString(),
-                LastSyncCompletedAt = feed.LastSyncCompletedAt,
+                LastSyncCompletedAt = feed.LastSyncCompletedAt ?? lastIngestedAt ?? lastSync?.CompletedAt ?? lastSync?.StartedAt,
                 ConsecutiveFailureCount = feed.ConsecutiveFailureCount,
                 LastRecordsCreated = lastSync?.RecordsCreated,
                 LastRecordsFetched = lastSync?.RecordsFetched,

--- a/src/backend/SniffleReport.Api/Data/AppDbContext.cs
+++ b/src/backend/SniffleReport.Api/Data/AppDbContext.cs
@@ -34,6 +34,12 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
 
     public DbSet<RegionSnapshot> RegionSnapshots => Set<RegionSnapshot>();
 
+    public DbSet<ShortageAreaDesignation> ShortageAreaDesignations => Set<ShortageAreaDesignation>();
+
+    public DbSet<WaterSystem> WaterSystems => Set<WaterSystem>();
+
+    public DbSet<WaterSystemViolation> WaterSystemViolations => Set<WaterSystemViolation>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -52,6 +58,9 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
         ConfigureFeedSyncLog(modelBuilder);
         ConfigureIngestedRecord(modelBuilder);
         ConfigureRegionSnapshot(modelBuilder);
+        ConfigureShortageAreaDesignation(modelBuilder);
+        ConfigureWaterSystem(modelBuilder);
+        ConfigureWaterSystemViolation(modelBuilder);
     }
 
     private static void ConfigureRegion(ModelBuilder modelBuilder)
@@ -234,6 +243,8 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
         entity.Property(x => x.TopAlertsJson).HasColumnType("jsonb");
         entity.Property(x => x.TrendHighlightsJson).HasColumnType("jsonb");
         entity.Property(x => x.ResourceCountsJson).HasColumnType("jsonb");
+        entity.Property(x => x.AccessSignalsJson).HasColumnType("jsonb");
+        entity.Property(x => x.EnvironmentalSignalsJson).HasColumnType("jsonb");
         entity.Property(x => x.PreventionHighlightsJson).HasColumnType("jsonb");
         entity.Property(x => x.NewsHighlightsJson).HasColumnType("jsonb");
         entity.HasIndex(x => x.RegionId)
@@ -244,6 +255,72 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
         entity.HasOne(x => x.Region)
             .WithOne()
             .HasForeignKey<RegionSnapshot>(x => x.RegionId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+
+    private static void ConfigureShortageAreaDesignation(ModelBuilder modelBuilder)
+    {
+        var entity = modelBuilder.Entity<ShortageAreaDesignation>();
+
+        entity.ToTable("ShortageAreaDesignations");
+        entity.Property(x => x.ExternalSourceId).HasMaxLength(128);
+        entity.Property(x => x.AreaName).HasMaxLength(300);
+        entity.Property(x => x.Discipline).HasMaxLength(120);
+        entity.Property(x => x.DesignationType).HasMaxLength(120);
+        entity.Property(x => x.Status).HasMaxLength(120);
+        entity.Property(x => x.PopulationGroup).HasMaxLength(200);
+        entity.Property(x => x.PopulationToProviderRatio).HasPrecision(12, 2);
+        entity.HasIndex(x => x.ExternalSourceId)
+            .IsUnique()
+            .HasDatabaseName("IX_ShortageAreaDesignation_ExternalSourceId");
+        entity.HasIndex(x => new { x.RegionId, x.Discipline })
+            .HasDatabaseName("IX_ShortageAreaDesignation_RegionId_Discipline");
+        entity.HasOne(x => x.Region)
+            .WithMany()
+            .HasForeignKey(x => x.RegionId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+
+    private static void ConfigureWaterSystem(ModelBuilder modelBuilder)
+    {
+        var entity = modelBuilder.Entity<WaterSystem>();
+
+        entity.ToTable("WaterSystems");
+        entity.Property(x => x.ExternalSourceId).HasMaxLength(64);
+        entity.Property(x => x.Name).HasMaxLength(300);
+        entity.Property(x => x.SystemType).HasMaxLength(120);
+        entity.Property(x => x.Address).HasMaxLength(300);
+        entity.Property(x => x.City).HasMaxLength(120);
+        entity.Property(x => x.State).HasMaxLength(32);
+        entity.Property(x => x.PostalCode).HasMaxLength(20);
+        entity.Property(x => x.CountyServed).HasMaxLength(120);
+        entity.HasIndex(x => x.ExternalSourceId)
+            .IsUnique()
+            .HasDatabaseName("IX_WaterSystem_ExternalSourceId");
+    }
+
+    private static void ConfigureWaterSystemViolation(ModelBuilder modelBuilder)
+    {
+        var entity = modelBuilder.Entity<WaterSystemViolation>();
+
+        entity.ToTable("WaterSystemViolations");
+        entity.Property(x => x.ExternalSourceId).HasMaxLength(128);
+        entity.Property(x => x.ViolationCategory).HasMaxLength(200);
+        entity.Property(x => x.RuleName).HasMaxLength(300);
+        entity.Property(x => x.ContaminantName).HasMaxLength(200);
+        entity.Property(x => x.Summary).HasMaxLength(2_000);
+        entity.HasIndex(x => x.ExternalSourceId)
+            .IsUnique()
+            .HasDatabaseName("IX_WaterSystemViolation_ExternalSourceId");
+        entity.HasIndex(x => new { x.RegionId, x.IsOpen })
+            .HasDatabaseName("IX_WaterSystemViolation_RegionId_IsOpen");
+        entity.HasOne(x => x.Region)
+            .WithMany()
+            .HasForeignKey(x => x.RegionId)
+            .OnDelete(DeleteBehavior.Cascade);
+        entity.HasOne(x => x.WaterSystem)
+            .WithMany(x => x.Violations)
+            .HasForeignKey(x => x.WaterSystemId)
             .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/src/backend/SniffleReport.Api/Data/DevelopmentDataSeeder.cs
+++ b/src/backend/SniffleReport.Api/Data/DevelopmentDataSeeder.cs
@@ -26,6 +26,8 @@ public static class DevelopmentDataSeeder
         await SeedDiseaseTrendsAsync(context, cancellationToken);
         await SeedPreventionGuidesAsync(context, cancellationToken);
         await SeedLocalResourcesAsync(context, cancellationToken);
+        await SeedShortageAreaDesignationsAsync(context, cancellationToken);
+        await SeedWaterSystemsAsync(context, cancellationToken);
         await SeedFeedSourcesAsync(context, cancellationToken);
 
         // Build initial region snapshots so the dashboard is ready immediately
@@ -261,6 +263,70 @@ public static class DevelopmentDataSeeder
         logger.LogInformation("Initial region snapshots built successfully.");
     }
 
+    private static async Task SeedShortageAreaDesignationsAsync(AppDbContext context, CancellationToken cancellationToken)
+    {
+        var regions = await GetRegionLookupAsync(context, cancellationToken);
+
+        foreach (var seed in GetShortageAreaSeeds(regions))
+        {
+            var existing = await context.ShortageAreaDesignations
+                .SingleOrDefaultAsync(d => d.ExternalSourceId == seed.ExternalSourceId, cancellationToken);
+
+            if (existing is null)
+            {
+                context.ShortageAreaDesignations.Add(seed);
+                continue;
+            }
+
+            seed.Id = existing.Id;
+            context.Entry(existing).CurrentValues.SetValues(seed);
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    private static async Task SeedWaterSystemsAsync(AppDbContext context, CancellationToken cancellationToken)
+    {
+        var regions = await GetRegionLookupAsync(context, cancellationToken);
+
+        foreach (var seed in GetWaterSystemSeeds())
+        {
+            var existing = await context.WaterSystems
+                .SingleOrDefaultAsync(s => s.ExternalSourceId == seed.ExternalSourceId, cancellationToken);
+
+            if (existing is null)
+            {
+                context.WaterSystems.Add(seed);
+                continue;
+            }
+
+            seed.Id = existing.Id;
+            context.Entry(existing).CurrentValues.SetValues(seed);
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        var systems = await context.WaterSystems
+            .ToDictionaryAsync(s => s.ExternalSourceId, cancellationToken);
+
+        foreach (var seed in GetWaterViolationSeeds(regions, systems))
+        {
+            var existing = await context.WaterSystemViolations
+                .SingleOrDefaultAsync(v => v.ExternalSourceId == seed.ExternalSourceId, cancellationToken);
+
+            if (existing is null)
+            {
+                context.WaterSystemViolations.Add(seed);
+                continue;
+            }
+
+            seed.Id = existing.Id;
+            context.Entry(existing).CurrentValues.SetValues(seed);
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
     private static async Task<Dictionary<string, Region>> GetRegionLookupAsync(AppDbContext context, CancellationToken cancellationToken)
     {
         var regions = await context.Regions.ToListAsync(cancellationToken);
@@ -449,6 +515,33 @@ public static class DevelopmentDataSeeder
             },
             new FeedSource
             {
+                Name = "HRSA Health Center Service Delivery Sites",
+                Type = FeedSourceType.HrsaHealthCenter,
+                Url = "https://data.hrsa.gov/DataDownload/Files/HealthCenterProgram/Health_Center_Service_Delivery_and_Look_Alike_Sites.csv",
+                PollingInterval = TimeSpan.FromDays(1),
+                IsEnabled = true,
+                LastSyncStatus = FeedSyncStatus.NeverRun
+            },
+            new FeedSource
+            {
+                Name = "HRSA Health Professional Shortage Areas",
+                Type = FeedSourceType.HrsaHpsa,
+                Url = "https://data.hrsa.gov/DataDownload/Files/ShortageAreas/BCD_HPSA_FCT_DET_PC.csv",
+                PollingInterval = TimeSpan.FromDays(1),
+                IsEnabled = true,
+                LastSyncStatus = FeedSyncStatus.NeverRun
+            },
+            new FeedSource
+            {
+                Name = "EPA Safe Drinking Water Violations",
+                Type = FeedSourceType.EpaSdwis,
+                Url = "https://data.epa.gov/efservice/SDW_VIOL_ENFORCEMENT/ROWS/0:5000/JSON",
+                PollingInterval = TimeSpan.FromDays(7),
+                IsEnabled = true,
+                LastSyncStatus = FeedSyncStatus.NeverRun
+            },
+            new FeedSource
+            {
                 Name = "openFDA Drug Enforcement",
                 Type = FeedSourceType.OpenFda,
                 Url = "drug/enforcement.json?limit=100&sort=report_date:desc",
@@ -495,6 +588,115 @@ public static class DevelopmentDataSeeder
             CreateTrend(alerts["Pertussis spike under active community monitoring"], new DateTime(2026, 2, 12, 0, 0, 0, DateTimeKind.Utc), 11),
             CreateTrend(alerts["Pertussis spike under active community monitoring"], new DateTime(2026, 2, 26, 0, 0, 0, DateTimeKind.Utc), 21),
             CreateTrend(alerts["Pertussis spike under active community monitoring"], new DateTime(2026, 3, 10, 0, 0, 0, DateTimeKind.Utc), 34)
+        ];
+    }
+
+    private static IEnumerable<ShortageAreaDesignation> GetShortageAreaSeeds(IReadOnlyDictionary<string, Region> regions)
+    {
+        return
+        [
+            new ShortageAreaDesignation
+            {
+                ExternalSourceId = "sample-hpsa-travis-primary",
+                RegionId = regions["Travis County"].Id,
+                AreaName = "Travis County primary care service area",
+                Discipline = "Primary Care",
+                DesignationType = "Geographic area",
+                Status = "Designated",
+                HpsaScore = 14,
+                PopulationToProviderRatio = 3550.2m,
+                SourceUpdatedAt = new DateTime(2026, 3, 11, 0, 0, 0, DateTimeKind.Utc)
+            },
+            new ShortageAreaDesignation
+            {
+                ExternalSourceId = "sample-hpsa-philadelphia-mental",
+                RegionId = regions["Philadelphia County"].Id,
+                AreaName = "Philadelphia County mental health service area",
+                Discipline = "Mental Health",
+                DesignationType = "Geographic area",
+                Status = "Designated",
+                HpsaScore = 17,
+                PopulationToProviderRatio = 4280.4m,
+                SourceUpdatedAt = new DateTime(2026, 3, 29, 0, 0, 0, DateTimeKind.Utc)
+            },
+            new ShortageAreaDesignation
+            {
+                ExternalSourceId = "sample-hpsa-hawaii-dental",
+                RegionId = regions["Hawaii County"].Id,
+                AreaName = "Hawaii County dental care service area",
+                Discipline = "Dental Health",
+                DesignationType = "Geographic area",
+                Status = "Designated",
+                HpsaScore = 18,
+                PopulationToProviderRatio = 5122.7m,
+                SourceUpdatedAt = new DateTime(2026, 3, 17, 0, 0, 0, DateTimeKind.Utc)
+            }
+        ];
+    }
+
+    private static IEnumerable<WaterSystem> GetWaterSystemSeeds()
+    {
+        return
+        [
+            new WaterSystem
+            {
+                ExternalSourceId = "sample-water-system-travis",
+                Name = "Central Travis Water Authority",
+                SystemType = "Community water system",
+                Address = "4100 Main St",
+                City = "Austin",
+                State = "TX",
+                PostalCode = "78701",
+                CountyServed = "Travis County",
+                PopulationServed = 182000
+            },
+            new WaterSystem
+            {
+                ExternalSourceId = "sample-water-system-philadelphia",
+                Name = "Philadelphia River Supply",
+                SystemType = "Community water system",
+                Address = "1200 River Ave",
+                City = "Philadelphia",
+                State = "PA",
+                PostalCode = "19107",
+                CountyServed = "Philadelphia County",
+                PopulationServed = 346000
+            }
+        ];
+    }
+
+    private static IEnumerable<WaterSystemViolation> GetWaterViolationSeeds(
+        IReadOnlyDictionary<string, Region> regions,
+        IReadOnlyDictionary<string, WaterSystem> systems)
+    {
+        return
+        [
+            new WaterSystemViolation
+            {
+                ExternalSourceId = "sample-water-violation-travis",
+                WaterSystemId = systems["sample-water-system-travis"].Id,
+                RegionId = regions["Travis County"].Id,
+                ViolationCategory = "Monitoring and reporting",
+                RuleName = "Lead and Copper Rule",
+                ContaminantName = "Lead",
+                Summary = "Open monitoring and reporting violation under the Lead and Copper Rule for a community water system serving central Travis County.",
+                IsOpen = true,
+                IdentifiedAt = new DateTime(2026, 2, 18, 0, 0, 0, DateTimeKind.Utc),
+                SourceUpdatedAt = new DateTime(2026, 3, 21, 0, 0, 0, DateTimeKind.Utc)
+            },
+            new WaterSystemViolation
+            {
+                ExternalSourceId = "sample-water-violation-philadelphia",
+                WaterSystemId = systems["sample-water-system-philadelphia"].Id,
+                RegionId = regions["Philadelphia County"].Id,
+                ViolationCategory = "Maximum contaminant level",
+                RuleName = "Total Trihalomethanes Rule",
+                ContaminantName = "Total trihalomethanes",
+                Summary = "Open maximum contaminant level violation for total trihalomethanes in a public water system serving Philadelphia County.",
+                IsOpen = true,
+                IdentifiedAt = new DateTime(2026, 1, 23, 0, 0, 0, DateTimeKind.Utc),
+                SourceUpdatedAt = new DateTime(2026, 3, 28, 0, 0, 0, DateTimeKind.Utc)
+            }
         ];
     }
 

--- a/src/backend/SniffleReport.Api/Data/Migrations/20260405230000_AddPhaseOneAccessAndWaterData.cs
+++ b/src/backend/SniffleReport.Api/Data/Migrations/20260405230000_AddPhaseOneAccessAndWaterData.cs
@@ -1,0 +1,163 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SniffleReport.Api.Data.Migrations;
+
+[DbContext(typeof(AppDbContext))]
+[Migration("20260405230000_AddPhaseOneAccessAndWaterData")]
+public partial class AddPhaseOneAccessAndWaterData : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "AccessSignalsJson",
+            table: "RegionSnapshots",
+            type: "jsonb",
+            nullable: false,
+            defaultValue: "[]");
+
+        migrationBuilder.AddColumn<string>(
+            name: "EnvironmentalSignalsJson",
+            table: "RegionSnapshots",
+            type: "jsonb",
+            nullable: false,
+            defaultValue: "[]");
+
+        migrationBuilder.CreateTable(
+            name: "ShortageAreaDesignations",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uuid", nullable: false),
+                RegionId = table.Column<Guid>(type: "uuid", nullable: false),
+                ExternalSourceId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                AreaName = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: false),
+                Discipline = table.Column<string>(type: "character varying(120)", maxLength: 120, nullable: false),
+                DesignationType = table.Column<string>(type: "character varying(120)", maxLength: 120, nullable: false),
+                Status = table.Column<string>(type: "character varying(120)", maxLength: 120, nullable: false),
+                PopulationGroup = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                HpsaScore = table.Column<int>(type: "integer", nullable: true),
+                PopulationToProviderRatio = table.Column<decimal>(type: "numeric(12,2)", precision: 12, scale: 2, nullable: true),
+                SourceUpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_ShortageAreaDesignations", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_ShortageAreaDesignations_Regions_RegionId",
+                    column: x => x.RegionId,
+                    principalTable: "Regions",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "WaterSystems",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uuid", nullable: false),
+                ExternalSourceId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                Name = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: false),
+                SystemType = table.Column<string>(type: "character varying(120)", maxLength: 120, nullable: true),
+                Address = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: true),
+                City = table.Column<string>(type: "character varying(120)", maxLength: 120, nullable: true),
+                State = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: true),
+                PostalCode = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                CountyServed = table.Column<string>(type: "character varying(120)", maxLength: 120, nullable: true),
+                PopulationServed = table.Column<int>(type: "integer", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_WaterSystems", x => x.Id);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "WaterSystemViolations",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uuid", nullable: false),
+                WaterSystemId = table.Column<Guid>(type: "uuid", nullable: false),
+                RegionId = table.Column<Guid>(type: "uuid", nullable: false),
+                ExternalSourceId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                ViolationCategory = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                RuleName = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: false),
+                ContaminantName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                Summary = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: false),
+                IsOpen = table.Column<bool>(type: "boolean", nullable: false),
+                IdentifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                ResolvedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                SourceUpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_WaterSystemViolations", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_WaterSystemViolations_Regions_RegionId",
+                    column: x => x.RegionId,
+                    principalTable: "Regions",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+                table.ForeignKey(
+                    name: "FK_WaterSystemViolations_WaterSystems_WaterSystemId",
+                    column: x => x.WaterSystemId,
+                    principalTable: "WaterSystems",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_ShortageAreaDesignation_ExternalSourceId",
+            table: "ShortageAreaDesignations",
+            column: "ExternalSourceId",
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_ShortageAreaDesignation_RegionId_Discipline",
+            table: "ShortageAreaDesignations",
+            columns: new[] { "RegionId", "Discipline" });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_WaterSystem_ExternalSourceId",
+            table: "WaterSystems",
+            column: "ExternalSourceId",
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_WaterSystemViolation_ExternalSourceId",
+            table: "WaterSystemViolations",
+            column: "ExternalSourceId",
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_WaterSystemViolation_RegionId_IsOpen",
+            table: "WaterSystemViolations",
+            columns: new[] { "RegionId", "IsOpen" });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_WaterSystemViolations_WaterSystemId",
+            table: "WaterSystemViolations",
+            column: "WaterSystemId");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "ShortageAreaDesignations");
+
+        migrationBuilder.DropTable(
+            name: "WaterSystemViolations");
+
+        migrationBuilder.DropTable(
+            name: "WaterSystems");
+
+        migrationBuilder.DropColumn(
+            name: "AccessSignalsJson",
+            table: "RegionSnapshots");
+
+        migrationBuilder.DropColumn(
+            name: "EnvironmentalSignalsJson",
+            table: "RegionSnapshots");
+    }
+}

--- a/src/backend/SniffleReport.Api/Models/DTOs/RegionDashboardDto.cs
+++ b/src/backend/SniffleReport.Api/Models/DTOs/RegionDashboardDto.cs
@@ -16,6 +16,10 @@ public sealed class RegionDashboardDto
 
     public SnapshotResourceCounts ResourceCounts { get; set; } = new();
 
+    public IReadOnlyList<SnapshotAccessSignalSummary> AccessSignals { get; set; } = [];
+
+    public IReadOnlyList<SnapshotEnvironmentalSignalSummary> EnvironmentalSignals { get; set; } = [];
+
     public IReadOnlyList<SnapshotPreventionSummary> PreventionHighlights { get; set; } = [];
 
     public IReadOnlyList<SnapshotNewsSummary> NewsHighlights { get; set; } = [];

--- a/src/backend/SniffleReport.Api/Models/Entities/RegionSnapshot.cs
+++ b/src/backend/SniffleReport.Api/Models/Entities/RegionSnapshot.cs
@@ -16,6 +16,10 @@ public sealed class RegionSnapshot : EntityBase
 
     public string ResourceCountsJson { get; set; } = "{}";
 
+    public string AccessSignalsJson { get; set; } = "[]";
+
+    public string EnvironmentalSignalsJson { get; set; } = "[]";
+
     public string PreventionHighlightsJson { get; set; } = "[]";
 
     public string NewsHighlightsJson { get; set; } = "[]";

--- a/src/backend/SniffleReport.Api/Models/Entities/ShortageAreaDesignation.cs
+++ b/src/backend/SniffleReport.Api/Models/Entities/ShortageAreaDesignation.cs
@@ -1,0 +1,26 @@
+namespace SniffleReport.Api.Models.Entities;
+
+public sealed class ShortageAreaDesignation : EntityBase
+{
+    public Guid RegionId { get; set; }
+
+    public Region Region { get; set; } = null!;
+
+    public string ExternalSourceId { get; set; } = string.Empty;
+
+    public string AreaName { get; set; } = string.Empty;
+
+    public string Discipline { get; set; } = string.Empty;
+
+    public string DesignationType { get; set; } = string.Empty;
+
+    public string Status { get; set; } = string.Empty;
+
+    public string? PopulationGroup { get; set; }
+
+    public int? HpsaScore { get; set; }
+
+    public decimal? PopulationToProviderRatio { get; set; }
+
+    public DateTime? SourceUpdatedAt { get; set; }
+}

--- a/src/backend/SniffleReport.Api/Models/Entities/WaterSystem.cs
+++ b/src/backend/SniffleReport.Api/Models/Entities/WaterSystem.cs
@@ -1,0 +1,24 @@
+namespace SniffleReport.Api.Models.Entities;
+
+public sealed class WaterSystem : EntityBase
+{
+    public string ExternalSourceId { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+
+    public string? SystemType { get; set; }
+
+    public string? Address { get; set; }
+
+    public string? City { get; set; }
+
+    public string? State { get; set; }
+
+    public string? PostalCode { get; set; }
+
+    public string? CountyServed { get; set; }
+
+    public int? PopulationServed { get; set; }
+
+    public ICollection<WaterSystemViolation> Violations { get; set; } = [];
+}

--- a/src/backend/SniffleReport.Api/Models/Entities/WaterSystemViolation.cs
+++ b/src/backend/SniffleReport.Api/Models/Entities/WaterSystemViolation.cs
@@ -1,0 +1,30 @@
+namespace SniffleReport.Api.Models.Entities;
+
+public sealed class WaterSystemViolation : EntityBase
+{
+    public Guid WaterSystemId { get; set; }
+
+    public WaterSystem WaterSystem { get; set; } = null!;
+
+    public Guid RegionId { get; set; }
+
+    public Region Region { get; set; } = null!;
+
+    public string ExternalSourceId { get; set; } = string.Empty;
+
+    public string ViolationCategory { get; set; } = string.Empty;
+
+    public string RuleName { get; set; } = string.Empty;
+
+    public string? ContaminantName { get; set; }
+
+    public string Summary { get; set; } = string.Empty;
+
+    public bool IsOpen { get; set; }
+
+    public DateTime? IdentifiedAt { get; set; }
+
+    public DateTime? ResolvedAt { get; set; }
+
+    public DateTime? SourceUpdatedAt { get; set; }
+}

--- a/src/backend/SniffleReport.Api/Models/Enums/FeedSourceType.cs
+++ b/src/backend/SniffleReport.Api/Models/Enums/FeedSourceType.cs
@@ -7,5 +7,7 @@ public enum FeedSourceType
     StateHealthDepartment = 2,
     NpiRegistry = 3,
     HrsaHealthCenter = 4,
-    OpenFda = 5
+    OpenFda = 5,
+    HrsaHpsa = 6,
+    EpaSdwis = 7
 }

--- a/src/backend/SniffleReport.Api/Models/Enums/NormalizedRecordType.cs
+++ b/src/backend/SniffleReport.Api/Models/Enums/NormalizedRecordType.cs
@@ -4,5 +4,7 @@ public enum NormalizedRecordType
 {
     TrendDataPoint = 0,
     NewsArticle = 1,
-    LocalResourceEntry = 2
+    LocalResourceEntry = 2,
+    ShortageAreaDesignation = 3,
+    DrinkingWaterViolation = 4
 }

--- a/src/backend/SniffleReport.Api/Models/Snapshots/SnapshotAccessSignalSummary.cs
+++ b/src/backend/SniffleReport.Api/Models/Snapshots/SnapshotAccessSignalSummary.cs
@@ -1,0 +1,22 @@
+namespace SniffleReport.Api.Models.Snapshots;
+
+public sealed class SnapshotAccessSignalSummary
+{
+    public Guid DesignationId { get; set; }
+
+    public string AreaName { get; set; } = string.Empty;
+
+    public string Discipline { get; set; } = string.Empty;
+
+    public string DesignationType { get; set; } = string.Empty;
+
+    public string Status { get; set; } = string.Empty;
+
+    public string? PopulationGroup { get; set; }
+
+    public int? HpsaScore { get; set; }
+
+    public decimal? PopulationToProviderRatio { get; set; }
+
+    public DateTime? SourceUpdatedAt { get; set; }
+}

--- a/src/backend/SniffleReport.Api/Models/Snapshots/SnapshotEnvironmentalSignalSummary.cs
+++ b/src/backend/SniffleReport.Api/Models/Snapshots/SnapshotEnvironmentalSignalSummary.cs
@@ -1,0 +1,24 @@
+namespace SniffleReport.Api.Models.Snapshots;
+
+public sealed class SnapshotEnvironmentalSignalSummary
+{
+    public Guid ViolationId { get; set; }
+
+    public string WaterSystemName { get; set; } = string.Empty;
+
+    public string ViolationCategory { get; set; } = string.Empty;
+
+    public string RuleName { get; set; } = string.Empty;
+
+    public string? ContaminantName { get; set; }
+
+    public string Summary { get; set; } = string.Empty;
+
+    public bool IsOpen { get; set; }
+
+    public int? PopulationServed { get; set; }
+
+    public DateTime? IdentifiedAt { get; set; }
+
+    public DateTime? SourceUpdatedAt { get; set; }
+}

--- a/src/backend/SniffleReport.Api/Program.cs
+++ b/src/backend/SniffleReport.Api/Program.cs
@@ -72,6 +72,11 @@ builder.Services.AddHttpClient("Hrsa", client =>
     client.Timeout = TimeSpan.FromSeconds(60);
     client.DefaultRequestHeaders.UserAgent.ParseAdd("SniffleReport/1.0");
 });
+builder.Services.AddHttpClient("EpaEnvirofacts", client =>
+{
+    client.Timeout = TimeSpan.FromSeconds(60);
+    client.DefaultRequestHeaders.UserAgent.ParseAdd("SniffleReport/1.0");
+});
 builder.Services.AddHttpClient("OpenFda", client =>
 {
     client.BaseAddress = new Uri("https://api.fda.gov/");
@@ -84,6 +89,8 @@ builder.Services.AddScoped<IFeedConnector, CdcSocrataConnector>();
 builder.Services.AddScoped<IFeedConnector, CdcRssConnector>();
 builder.Services.AddScoped<IFeedConnector, NpiRegistryConnector>();
 builder.Services.AddScoped<IFeedConnector, HrsaConnector>();
+builder.Services.AddScoped<IFeedConnector, HrsaHpsaConnector>();
+builder.Services.AddScoped<IFeedConnector, EpaSdwisConnector>();
 builder.Services.AddScoped<IFeedConnector, OpenFdaConnector>();
 builder.Services.AddScoped<RegionMappingService>();
 builder.Services.AddScoped<AlertThresholdService>();

--- a/src/backend/SniffleReport.Api/Services/Ingestion/Connectors/CsvRecordReader.cs
+++ b/src/backend/SniffleReport.Api/Services/Ingestion/Connectors/CsvRecordReader.cs
@@ -1,0 +1,72 @@
+using System.Text;
+using Microsoft.VisualBasic.FileIO;
+
+namespace SniffleReport.Api.Services.Ingestion.Connectors;
+
+internal static class CsvRecordReader
+{
+    public static IReadOnlyList<Dictionary<string, string>> Parse(string csvText)
+    {
+        using var parser = new TextFieldParser(new StringReader(csvText));
+        parser.TextFieldType = FieldType.Delimited;
+        parser.SetDelimiters(",");
+        parser.HasFieldsEnclosedInQuotes = true;
+
+        if (parser.EndOfData)
+        {
+            return [];
+        }
+
+        var headers = parser.ReadFields()?.Select(NormalizeHeader).ToArray() ?? [];
+        var records = new List<Dictionary<string, string>>();
+
+        while (!parser.EndOfData)
+        {
+            var fields = parser.ReadFields();
+            if (fields is null)
+            {
+                continue;
+            }
+
+            var record = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; i < headers.Length && i < fields.Length; i++)
+            {
+                record[headers[i]] = fields[i].Trim();
+            }
+
+            records.Add(record);
+        }
+
+        return records;
+    }
+
+    public static string? GetValue(
+        IReadOnlyDictionary<string, string> row,
+        params string[] candidateHeaders)
+    {
+        foreach (var header in candidateHeaders)
+        {
+            var normalized = NormalizeHeader(header);
+            if (row.TryGetValue(normalized, out var value) && !string.IsNullOrWhiteSpace(value))
+            {
+                return value.Trim();
+            }
+        }
+
+        return null;
+    }
+
+    private static string NormalizeHeader(string header)
+    {
+        var builder = new StringBuilder(header.Length);
+        foreach (var character in header)
+        {
+            if (char.IsLetterOrDigit(character))
+            {
+                builder.Append(char.ToUpperInvariant(character));
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/backend/SniffleReport.Api/Services/Ingestion/Connectors/EpaSdwisConnector.cs
+++ b/src/backend/SniffleReport.Api/Services/Ingestion/Connectors/EpaSdwisConnector.cs
@@ -1,0 +1,148 @@
+using System.Globalization;
+using System.Text.Json;
+using SniffleReport.Api.Models.Entities;
+using SniffleReport.Api.Models.Enums;
+
+namespace SniffleReport.Api.Services.Ingestion.Connectors;
+
+public sealed class EpaSdwisConnector(
+    IHttpClientFactory httpClientFactory,
+    ILogger<EpaSdwisConnector> logger) : IFeedConnector
+{
+    public FeedSourceType SourceType => FeedSourceType.EpaSdwis;
+
+    public async Task<FeedFetchResult> FetchAsync(FeedSource source, CancellationToken ct)
+    {
+        var client = httpClientFactory.CreateClient("EpaEnvirofacts");
+
+        try
+        {
+            logger.LogInformation("Fetching EPA SDWIS data from {Url}", source.Url);
+            var response = await client.GetAsync(source.Url.Trim(), ct);
+            response.EnsureSuccessStatusCode();
+
+            var payload = await response.Content.ReadAsStringAsync(ct);
+            using var document = JsonDocument.Parse(payload);
+
+            if (document.RootElement.ValueKind != JsonValueKind.Array)
+            {
+                return FeedFetchResult.Failure("EPA SDWIS feed did not return a JSON array.");
+            }
+
+            var records = new List<NormalizedFeedRecord>();
+            foreach (var item in document.RootElement.EnumerateArray())
+            {
+                var record = ParseViolation(item);
+                if (record is not null)
+                {
+                    records.Add(record);
+                }
+            }
+
+            logger.LogInformation("Parsed {Count} EPA SDWIS records for {FeedName}", records.Count, source.Name);
+            return FeedFetchResult.Success(records);
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogError(ex, "HTTP error fetching EPA SDWIS data for {FeedName}", source.Name);
+            return FeedFetchResult.Failure($"HTTP {ex.StatusCode}: {ex.Message}");
+        }
+        catch (TaskCanceledException) when (ct.IsCancellationRequested) { throw; }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error fetching EPA SDWIS data for {FeedName}", source.Name);
+            return FeedFetchResult.Failure(ex.Message);
+        }
+    }
+
+    private static NormalizedFeedRecord? ParseViolation(JsonElement item)
+    {
+        var pwsId = GetString(item, "pwsid");
+        var violationId = GetString(item, "violation_id");
+        var state = GetString(item, "primacy_agency_code")
+            ?? GetString(item, "state");
+        var county = GetString(item, "county_served")
+            ?? GetString(item, "county_served_name");
+
+        if (pwsId is null || violationId is null || state is null || county is null)
+        {
+            return null;
+        }
+
+        var jurisdictionName = $"{county}, {state}";
+        var isOpen = !string.Equals(GetString(item, "violation_status"), "Resolved", StringComparison.OrdinalIgnoreCase);
+        var category = GetString(item, "violation_category") ?? "Drinking water violation";
+        var ruleName = GetString(item, "rule_family") ?? GetString(item, "rule_code") ?? "EPA SDWIS rule";
+        var contaminantName = GetString(item, "contaminant_code") ?? GetString(item, "contaminant_name");
+
+        return new NormalizedFeedRecord
+        {
+            ExternalSourceId = $"sdwis:{pwsId}:{violationId}",
+            ParentExternalSourceId = $"sdwis-system:{pwsId}",
+            RawPayloadJson = item.GetRawText(),
+            RecordType = NormalizedRecordType.DrinkingWaterViolation,
+            JurisdictionName = jurisdictionName,
+            WaterSystemName = GetString(item, "pws_name") ?? pwsId,
+            WaterSystemType = GetString(item, "pws_type_code"),
+            WaterSystemAddress = GetString(item, "address_line1_txt"),
+            WaterSystemCity = GetString(item, "city_name"),
+            WaterSystemState = state,
+            WaterSystemPostalCode = GetString(item, "zip_code"),
+            CountyServed = county,
+            PopulationServed = ParseNullableInt(GetString(item, "population_served_count")),
+            ViolationCategory = category,
+            RuleName = ruleName,
+            ContaminantName = contaminantName,
+            Summary = BuildSummary(category, ruleName, contaminantName, county),
+            IsOpenViolation = isOpen,
+            IdentifiedAt = ParseNullableDate(GetString(item, "violation_begin_date")),
+            ResolvedAt = ParseNullableDate(GetString(item, "violation_end_date")),
+            SourceDate = ParseNullableDate(GetString(item, "compliance_period_end_date"))
+                ?? ParseNullableDate(GetString(item, "violation_begin_date")),
+            SourceAttribution = "EPA Safe Drinking Water Information System"
+        };
+    }
+
+    private static string BuildSummary(
+        string category,
+        string ruleName,
+        string? contaminantName,
+        string county)
+    {
+        if (!string.IsNullOrWhiteSpace(contaminantName))
+        {
+            return $"{category} under {ruleName} involving {contaminantName} for a public water system serving {county}.";
+        }
+
+        return $"{category} under {ruleName} for a public water system serving {county}.";
+    }
+
+    private static string? GetString(JsonElement element, string name)
+    {
+        if (element.TryGetProperty(name, out var property))
+        {
+            return property.ValueKind switch
+            {
+                JsonValueKind.String => string.IsNullOrWhiteSpace(property.GetString()) ? null : property.GetString()?.Trim(),
+                JsonValueKind.Number => property.GetRawText(),
+                _ => null
+            };
+        }
+
+        return null;
+    }
+
+    private static int? ParseNullableInt(string? value)
+    {
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : null;
+    }
+
+    private static DateTime? ParseNullableDate(string? value)
+    {
+        return DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var parsed)
+            ? parsed.ToUniversalTime()
+            : null;
+    }
+}

--- a/src/backend/SniffleReport.Api/Services/Ingestion/Connectors/HrsaConnector.cs
+++ b/src/backend/SniffleReport.Api/Services/Ingestion/Connectors/HrsaConnector.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using SniffleReport.Api.Models.Entities;
 using SniffleReport.Api.Models.Enums;
@@ -23,27 +24,41 @@ public sealed class HrsaConnector(
             var response = await client.GetAsync(url, ct);
             response.EnsureSuccessStatusCode();
 
-            var json = await response.Content.ReadAsStringAsync(ct);
-            using var doc = JsonDocument.Parse(json);
-
+            var payload = await response.Content.ReadAsStringAsync(ct);
             var records = new List<NormalizedFeedRecord>();
 
-            if (doc.RootElement.TryGetProperty("results", out var results))
+            if (LooksLikeCsv(payload))
             {
-                foreach (var center in results.EnumerateArray())
+                foreach (var row in CsvRecordReader.Parse(payload))
                 {
-                    var record = ParseCenter(center, source);
+                    var record = ParseCenter(row, source);
                     if (record is not null)
+                    {
                         records.Add(record);
+                    }
                 }
             }
-            else if (doc.RootElement.ValueKind == JsonValueKind.Array)
+            else
             {
-                foreach (var center in doc.RootElement.EnumerateArray())
+                using var doc = JsonDocument.Parse(payload);
+
+                if (doc.RootElement.TryGetProperty("results", out var results))
                 {
-                    var record = ParseCenter(center, source);
-                    if (record is not null)
-                        records.Add(record);
+                    foreach (var center in results.EnumerateArray())
+                    {
+                        var record = ParseCenter(center, source);
+                        if (record is not null)
+                            records.Add(record);
+                    }
+                }
+                else if (doc.RootElement.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var center in doc.RootElement.EnumerateArray())
+                    {
+                        var record = ParseCenter(center, source);
+                        if (record is not null)
+                            records.Add(record);
+                    }
                 }
             }
 
@@ -61,6 +76,12 @@ public sealed class HrsaConnector(
             logger.LogError(ex, "Error fetching HRSA data for {FeedName}", source.Name);
             return FeedFetchResult.Failure(ex.Message);
         }
+    }
+
+    private static bool LooksLikeCsv(string payload)
+    {
+        var trimmed = payload.TrimStart();
+        return !trimmed.StartsWith("{", StringComparison.Ordinal) && !trimmed.StartsWith("[", StringComparison.Ordinal);
     }
 
     private static NormalizedFeedRecord? ParseCenter(JsonElement center, FeedSource source)
@@ -101,6 +122,48 @@ public sealed class HrsaConnector(
         };
     }
 
+    private static NormalizedFeedRecord? ParseCenter(
+        IReadOnlyDictionary<string, string> row,
+        FeedSource source)
+    {
+        var name = CsvRecordReader.GetValue(row, "health_center_site_name", "site_name", "name");
+        var state = CsvRecordReader.GetValue(row, "site_state_abbreviation", "state");
+
+        if (name is null || state is null)
+        {
+            return null;
+        }
+
+        var address = CsvRecordReader.GetValue(row, "site_address", "street_address", "address");
+        var city = CsvRecordReader.GetValue(row, "site_city", "city");
+        var zip = CsvRecordReader.GetValue(row, "site_postal_code", "zip", "postal_code");
+        var phone = CsvRecordReader.GetValue(row, "main_phone_number", "phone", "telephone");
+        var website = CsvRecordReader.GetValue(row, "website_url", "website", "url");
+        var id = CsvRecordReader.GetValue(row, "site_id", "id") ?? name;
+        var latitude = ParseNullableDouble(CsvRecordReader.GetValue(row, "latitude", "site_latitude"));
+        var longitude = ParseNullableDouble(CsvRecordReader.GetValue(row, "longitude", "site_longitude"));
+
+        var fullAddress = string.Join(", ",
+            new[] { address, city, $"{state} {zip}" }.Where(s => !string.IsNullOrWhiteSpace(s)));
+
+        return new NormalizedFeedRecord
+        {
+            ExternalSourceId = $"hrsa:{state}:{id}",
+            RawPayloadJson = JsonSerializer.Serialize(row),
+            RecordType = NormalizedRecordType.LocalResourceEntry,
+            JurisdictionName = state,
+            ResourceName = name.Length > 200 ? name[..200] : name,
+            Address = fullAddress.Length > 300 ? fullAddress[..300] : fullAddress,
+            Phone = phone?.Length > 40 ? phone[..40] : phone,
+            Website = website?.Length > 500 ? website[..500] : website,
+            Latitude = latitude,
+            Longitude = longitude,
+            ResourceType = ResourceType.Clinic,
+            SourceAttribution = "HRSA Health Center Service Delivery Sites"
+        };
+    }
+
+
     private static string? GetField(JsonElement element, string name)
     {
         if (element.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.String)
@@ -121,5 +184,17 @@ public sealed class HrsaConnector(
                 return d2;
         }
         return null;
+    }
+
+    private static double? ParseNullableDouble(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : null;
     }
 }

--- a/src/backend/SniffleReport.Api/Services/Ingestion/Connectors/HrsaHpsaConnector.cs
+++ b/src/backend/SniffleReport.Api/Services/Ingestion/Connectors/HrsaHpsaConnector.cs
@@ -1,0 +1,112 @@
+using System.Globalization;
+using System.Text.Json;
+using SniffleReport.Api.Models.Entities;
+using SniffleReport.Api.Models.Enums;
+
+namespace SniffleReport.Api.Services.Ingestion.Connectors;
+
+public sealed class HrsaHpsaConnector(
+    IHttpClientFactory httpClientFactory,
+    ILogger<HrsaHpsaConnector> logger) : IFeedConnector
+{
+    public FeedSourceType SourceType => FeedSourceType.HrsaHpsa;
+
+    public async Task<FeedFetchResult> FetchAsync(FeedSource source, CancellationToken ct)
+    {
+        var client = httpClientFactory.CreateClient("Hrsa");
+
+        try
+        {
+            logger.LogInformation("Fetching HRSA HPSA data from {Url}", source.Url);
+            var response = await client.GetAsync(source.Url.Trim(), ct);
+            response.EnsureSuccessStatusCode();
+
+            var csv = await response.Content.ReadAsStringAsync(ct);
+            var records = new List<NormalizedFeedRecord>();
+
+            foreach (var row in CsvRecordReader.Parse(csv))
+            {
+                var record = ParseHpsa(row);
+                if (record is not null)
+                {
+                    records.Add(record);
+                }
+            }
+
+            logger.LogInformation("Parsed {Count} HRSA HPSA records for {FeedName}", records.Count, source.Name);
+            return FeedFetchResult.Success(records);
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogError(ex, "HTTP error fetching HRSA HPSA data for {FeedName}", source.Name);
+            return FeedFetchResult.Failure($"HTTP {ex.StatusCode}: {ex.Message}");
+        }
+        catch (TaskCanceledException) when (ct.IsCancellationRequested) { throw; }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error fetching HRSA HPSA data for {FeedName}", source.Name);
+            return FeedFetchResult.Failure(ex.Message);
+        }
+    }
+
+    private static NormalizedFeedRecord? ParseHpsa(IReadOnlyDictionary<string, string> row)
+    {
+        var state = CsvRecordReader.GetValue(row, "state_abbreviation", "state")
+            ?? CsvRecordReader.GetValue(row, "common_state_abbreviation");
+        var countyName = CsvRecordReader.GetValue(row, "county_name", "county", "common_county_name");
+        var areaName = CsvRecordReader.GetValue(row, "hpsa_name", "name", "designation_name");
+        var discipline = CsvRecordReader.GetValue(row, "hpsa_discipline_class", "discipline", "hpsa_discipline");
+        var designationType = CsvRecordReader.GetValue(row, "hpsa_designation_type", "designation_type");
+        var status = CsvRecordReader.GetValue(row, "hpsa_status", "status") ?? "Designated";
+        var hpsaId = CsvRecordReader.GetValue(row, "hpsa_id", "id");
+
+        if (state is null || areaName is null || discipline is null || hpsaId is null)
+        {
+            return null;
+        }
+
+        var jurisdictionName = !string.IsNullOrWhiteSpace(countyName)
+            ? $"{countyName}, {state}"
+            : state;
+
+        return new NormalizedFeedRecord
+        {
+            ExternalSourceId = $"hpsa:{hpsaId}",
+            RawPayloadJson = JsonSerializer.Serialize(row),
+            RecordType = NormalizedRecordType.ShortageAreaDesignation,
+            JurisdictionName = jurisdictionName,
+            AreaName = areaName,
+            Discipline = discipline,
+            DesignationType = designationType ?? "Geographic area",
+            DesignationStatus = status,
+            PopulationGroup = CsvRecordReader.GetValue(row, "population_type", "population_group"),
+            HpsaScore = ParseNullableInt(CsvRecordReader.GetValue(row, "hpsa_score", "score")),
+            PopulationToProviderRatio = ParseNullableDecimal(
+                CsvRecordReader.GetValue(row, "population_to_provider_ratio", "populationproviderratio")),
+            SourceDate = ParseNullableDate(
+                CsvRecordReader.GetValue(row, "designation_date", "designation_last_update_date", "last_update_date")),
+            SourceAttribution = "HRSA Health Professional Shortage Areas"
+        };
+    }
+
+    private static int? ParseNullableInt(string? value)
+    {
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : null;
+    }
+
+    private static decimal? ParseNullableDecimal(string? value)
+    {
+        return decimal.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : null;
+    }
+
+    private static DateTime? ParseNullableDate(string? value)
+    {
+        return DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var parsed)
+            ? parsed.ToUniversalTime()
+            : null;
+    }
+}

--- a/src/backend/SniffleReport.Api/Services/Ingestion/IngestionService.cs
+++ b/src/backend/SniffleReport.Api/Services/Ingestion/IngestionService.cs
@@ -145,8 +145,7 @@ public sealed class IngestionService(
                 FeedSourceId = source.Id,
                 ExternalSourceId = record.ExternalSourceId,
                 PayloadHash = payloadHash,
-                TargetEntityType = record.RecordType == NormalizedRecordType.TrendDataPoint
-                    ? nameof(DiseaseTrend) : nameof(NewsItem),
+                TargetEntityType = GetTargetEntityTypeName(record.RecordType),
                 TargetEntityId = Guid.Empty
             });
             syncLog.RecordsSkippedUnmappable++;
@@ -190,6 +189,12 @@ public sealed class IngestionService(
 
             case NormalizedRecordType.LocalResourceEntry:
                 return await CreateLocalResourceFromRecordAsync(record, regionId, source, ct);
+
+            case NormalizedRecordType.ShortageAreaDesignation:
+                return CreateShortageAreaDesignationFromRecord(record, regionId, source);
+
+            case NormalizedRecordType.DrinkingWaterViolation:
+                return await CreateDrinkingWaterViolationFromRecordAsync(record, regionId, source, ct);
 
             default:
                 throw new ArgumentOutOfRangeException(nameof(record), $"Unknown record type: {record.RecordType}");
@@ -324,6 +329,105 @@ public sealed class IngestionService(
         return (nameof(LocalResource), resource.Id);
     }
 
+    private (string, Guid) CreateShortageAreaDesignationFromRecord(
+        NormalizedFeedRecord record,
+        Guid regionId,
+        FeedSource source)
+    {
+        var designation = new ShortageAreaDesignation
+        {
+            RegionId = regionId,
+            ExternalSourceId = record.ExternalSourceId,
+            AreaName = record.AreaName?.Trim() ?? record.JurisdictionName?.Trim() ?? "Unknown shortage area",
+            Discipline = record.Discipline?.Trim() ?? "Primary care",
+            DesignationType = record.DesignationType?.Trim() ?? "Geographic area",
+            Status = record.DesignationStatus?.Trim() ?? "Designated",
+            PopulationGroup = record.PopulationGroup?.Trim(),
+            HpsaScore = record.HpsaScore,
+            PopulationToProviderRatio = record.PopulationToProviderRatio,
+            SourceUpdatedAt = record.SourceDate
+        };
+        dbContext.ShortageAreaDesignations.Add(designation);
+
+        dbContext.AuditLogEntries.Add(AdminAuditLog.Create(
+            _options.SystemUserId,
+            AuditLogAction.FeedIngest,
+            nameof(ShortageAreaDesignation),
+            designation.Id,
+            null,
+            new { designation.RegionId, designation.AreaName, designation.Discipline, FeedSource = source.Name },
+            $"Ingested from {source.Name}"));
+
+        return (nameof(ShortageAreaDesignation), designation.Id);
+    }
+
+    private async Task<(string, Guid)> CreateDrinkingWaterViolationFromRecordAsync(
+        NormalizedFeedRecord record,
+        Guid regionId,
+        FeedSource source,
+        CancellationToken ct)
+    {
+        var waterSystemExternalId = record.ParentExternalSourceId?.Trim();
+        var waterSystem = waterSystemExternalId is null
+            ? null
+            : await dbContext.WaterSystems.FirstOrDefaultAsync(s => s.ExternalSourceId == waterSystemExternalId, ct);
+
+        if (waterSystem is null)
+        {
+            waterSystem = new WaterSystem
+            {
+                ExternalSourceId = waterSystemExternalId ?? record.ExternalSourceId,
+                Name = record.WaterSystemName?.Trim() ?? "Unknown water system",
+                SystemType = record.WaterSystemType?.Trim(),
+                Address = record.WaterSystemAddress?.Trim(),
+                City = record.WaterSystemCity?.Trim(),
+                State = record.WaterSystemState?.Trim(),
+                PostalCode = record.WaterSystemPostalCode?.Trim(),
+                CountyServed = record.CountyServed?.Trim(),
+                PopulationServed = record.PopulationServed
+            };
+            dbContext.WaterSystems.Add(waterSystem);
+        }
+        else
+        {
+            waterSystem.Name = record.WaterSystemName?.Trim() ?? waterSystem.Name;
+            waterSystem.SystemType = record.WaterSystemType?.Trim() ?? waterSystem.SystemType;
+            waterSystem.Address = record.WaterSystemAddress?.Trim() ?? waterSystem.Address;
+            waterSystem.City = record.WaterSystemCity?.Trim() ?? waterSystem.City;
+            waterSystem.State = record.WaterSystemState?.Trim() ?? waterSystem.State;
+            waterSystem.PostalCode = record.WaterSystemPostalCode?.Trim() ?? waterSystem.PostalCode;
+            waterSystem.CountyServed = record.CountyServed?.Trim() ?? waterSystem.CountyServed;
+            waterSystem.PopulationServed = record.PopulationServed ?? waterSystem.PopulationServed;
+        }
+
+        var violation = new WaterSystemViolation
+        {
+            WaterSystem = waterSystem,
+            RegionId = regionId,
+            ExternalSourceId = record.ExternalSourceId,
+            ViolationCategory = record.ViolationCategory?.Trim() ?? "Drinking water violation",
+            RuleName = record.RuleName?.Trim() ?? "EPA SDWIS rule",
+            ContaminantName = record.ContaminantName?.Trim(),
+            Summary = record.Summary?.Trim() ?? "EPA drinking water violation.",
+            IsOpen = record.IsOpenViolation ?? true,
+            IdentifiedAt = record.IdentifiedAt,
+            ResolvedAt = record.ResolvedAt,
+            SourceUpdatedAt = record.SourceDate
+        };
+        dbContext.WaterSystemViolations.Add(violation);
+
+        dbContext.AuditLogEntries.Add(AdminAuditLog.Create(
+            _options.SystemUserId,
+            AuditLogAction.FeedIngest,
+            nameof(WaterSystemViolation),
+            violation.Id,
+            null,
+            new { violation.RegionId, violation.ViolationCategory, violation.RuleName, FeedSource = source.Name },
+            $"Ingested from {source.Name}"));
+
+        return (nameof(WaterSystemViolation), violation.Id);
+    }
+
     private async Task<HealthAlert> FindOrCreateAlertAsync(
         Guid regionId,
         string disease,
@@ -414,7 +518,79 @@ public sealed class IngestionService(
                     news.Content = record.Summary?.Trim() ?? news.Content;
                 }
                 break;
+
+            case nameof(LocalResource):
+                var resource = await dbContext.LocalResources
+                    .FirstOrDefaultAsync(r => r.Id == ingestedRecord.TargetEntityId, ct);
+                if (resource is not null)
+                {
+                    resource.Address = record.Address?.Trim() ?? resource.Address;
+                    resource.Phone = record.Phone ?? resource.Phone;
+                    resource.Website = record.Website ?? resource.Website;
+                    resource.Latitude = record.Latitude ?? resource.Latitude;
+                    resource.Longitude = record.Longitude ?? resource.Longitude;
+                    if (record.ResourceType.HasValue)
+                    {
+                        resource.Type = record.ResourceType.Value;
+                    }
+                }
+                break;
+
+            case nameof(ShortageAreaDesignation):
+                var designation = await dbContext.ShortageAreaDesignations
+                    .FirstOrDefaultAsync(d => d.Id == ingestedRecord.TargetEntityId, ct);
+                if (designation is not null)
+                {
+                    designation.AreaName = record.AreaName?.Trim() ?? designation.AreaName;
+                    designation.Discipline = record.Discipline?.Trim() ?? designation.Discipline;
+                    designation.DesignationType = record.DesignationType?.Trim() ?? designation.DesignationType;
+                    designation.Status = record.DesignationStatus?.Trim() ?? designation.Status;
+                    designation.PopulationGroup = record.PopulationGroup?.Trim() ?? designation.PopulationGroup;
+                    designation.HpsaScore = record.HpsaScore ?? designation.HpsaScore;
+                    designation.PopulationToProviderRatio = record.PopulationToProviderRatio ?? designation.PopulationToProviderRatio;
+                    designation.SourceUpdatedAt = record.SourceDate ?? designation.SourceUpdatedAt;
+                }
+                break;
+
+            case nameof(WaterSystemViolation):
+                var violation = await dbContext.WaterSystemViolations
+                    .Include(v => v.WaterSystem)
+                    .FirstOrDefaultAsync(v => v.Id == ingestedRecord.TargetEntityId, ct);
+                if (violation is not null)
+                {
+                    violation.ViolationCategory = record.ViolationCategory?.Trim() ?? violation.ViolationCategory;
+                    violation.RuleName = record.RuleName?.Trim() ?? violation.RuleName;
+                    violation.ContaminantName = record.ContaminantName?.Trim() ?? violation.ContaminantName;
+                    violation.Summary = record.Summary?.Trim() ?? violation.Summary;
+                    violation.IsOpen = record.IsOpenViolation ?? violation.IsOpen;
+                    violation.IdentifiedAt = record.IdentifiedAt ?? violation.IdentifiedAt;
+                    violation.ResolvedAt = record.ResolvedAt ?? violation.ResolvedAt;
+                    violation.SourceUpdatedAt = record.SourceDate ?? violation.SourceUpdatedAt;
+
+                    violation.WaterSystem.Name = record.WaterSystemName?.Trim() ?? violation.WaterSystem.Name;
+                    violation.WaterSystem.SystemType = record.WaterSystemType?.Trim() ?? violation.WaterSystem.SystemType;
+                    violation.WaterSystem.Address = record.WaterSystemAddress?.Trim() ?? violation.WaterSystem.Address;
+                    violation.WaterSystem.City = record.WaterSystemCity?.Trim() ?? violation.WaterSystem.City;
+                    violation.WaterSystem.State = record.WaterSystemState?.Trim() ?? violation.WaterSystem.State;
+                    violation.WaterSystem.PostalCode = record.WaterSystemPostalCode?.Trim() ?? violation.WaterSystem.PostalCode;
+                    violation.WaterSystem.CountyServed = record.CountyServed?.Trim() ?? violation.WaterSystem.CountyServed;
+                    violation.WaterSystem.PopulationServed = record.PopulationServed ?? violation.WaterSystem.PopulationServed;
+                }
+                break;
         }
+    }
+
+    private static string GetTargetEntityTypeName(NormalizedRecordType recordType)
+    {
+        return recordType switch
+        {
+            NormalizedRecordType.TrendDataPoint => nameof(DiseaseTrend),
+            NormalizedRecordType.NewsArticle => nameof(NewsItem),
+            NormalizedRecordType.LocalResourceEntry => nameof(LocalResource),
+            NormalizedRecordType.ShortageAreaDesignation => nameof(ShortageAreaDesignation),
+            NormalizedRecordType.DrinkingWaterViolation => nameof(WaterSystemViolation),
+            _ => nameof(NewsItem)
+        };
     }
 
     private static string ComputeHash(string payload)

--- a/src/backend/SniffleReport.Api/Services/Ingestion/NormalizedFeedRecord.cs
+++ b/src/backend/SniffleReport.Api/Services/Ingestion/NormalizedFeedRecord.cs
@@ -43,4 +43,50 @@ public sealed class NormalizedFeedRecord
     public double? Longitude { get; init; }
 
     public ResourceType? ResourceType { get; init; }
+
+    // Fields for ShortageAreaDesignation records
+    public string? AreaName { get; init; }
+
+    public string? Discipline { get; init; }
+
+    public string? DesignationType { get; init; }
+
+    public string? DesignationStatus { get; init; }
+
+    public string? PopulationGroup { get; init; }
+
+    public int? HpsaScore { get; init; }
+
+    public decimal? PopulationToProviderRatio { get; init; }
+
+    // Fields for DrinkingWaterViolation records
+    public string? ParentExternalSourceId { get; init; }
+
+    public string? WaterSystemName { get; init; }
+
+    public string? WaterSystemType { get; init; }
+
+    public string? WaterSystemAddress { get; init; }
+
+    public string? WaterSystemCity { get; init; }
+
+    public string? WaterSystemState { get; init; }
+
+    public string? WaterSystemPostalCode { get; init; }
+
+    public string? CountyServed { get; init; }
+
+    public int? PopulationServed { get; init; }
+
+    public string? ViolationCategory { get; init; }
+
+    public string? RuleName { get; init; }
+
+    public string? ContaminantName { get; init; }
+
+    public bool? IsOpenViolation { get; init; }
+
+    public DateTime? IdentifiedAt { get; init; }
+
+    public DateTime? ResolvedAt { get; init; }
 }

--- a/src/backend/SniffleReport.Api/Services/Snapshots/RegionSnapshotBuilder.cs
+++ b/src/backend/SniffleReport.Api/Services/Snapshots/RegionSnapshotBuilder.cs
@@ -33,6 +33,8 @@ public sealed class RegionSnapshotBuilder(
         var newsByRegion = await LoadNewsByRegionAsync(ct);
         var preventionByRegion = await LoadPreventionByRegionAsync(ct);
         var resourcesByRegion = await LoadResourcesByRegionAsync(ct);
+        var shortageAreasByRegion = await LoadShortageAreasByRegionAsync(ct);
+        var waterSignalsByRegion = await LoadWaterSignalsByRegionAsync(ct);
 
         // Step 3: Load existing snapshots for upsert
         var existingSnapshots = await dbContext.RegionSnapshots
@@ -47,7 +49,7 @@ public sealed class RegionSnapshotBuilder(
             var snapshot = BuildSnapshotForRegion(
                 regionId, descendantIds, now, config,
                 alertsByRegion, trendsByAlert, newsByRegion,
-                preventionByRegion, resourcesByRegion);
+                preventionByRegion, resourcesByRegion, shortageAreasByRegion, waterSignalsByRegion);
 
             if (existingSnapshots.TryGetValue(regionId, out var existing))
             {
@@ -56,6 +58,8 @@ public sealed class RegionSnapshotBuilder(
                 existing.TopAlertsJson = snapshot.TopAlertsJson;
                 existing.TrendHighlightsJson = snapshot.TrendHighlightsJson;
                 existing.ResourceCountsJson = snapshot.ResourceCountsJson;
+                existing.AccessSignalsJson = snapshot.AccessSignalsJson;
+                existing.EnvironmentalSignalsJson = snapshot.EnvironmentalSignalsJson;
                 existing.PreventionHighlightsJson = snapshot.PreventionHighlightsJson;
                 existing.NewsHighlightsJson = snapshot.NewsHighlightsJson;
             }
@@ -92,18 +96,27 @@ public sealed class RegionSnapshotBuilder(
         Dictionary<Guid, List<TrendData>> trendsByAlert,
         Dictionary<Guid, List<NewsData>> newsByRegion,
         Dictionary<Guid, List<PreventionData>> preventionByRegion,
-        Dictionary<Guid, List<ResourceData>> resourcesByRegion)
+        Dictionary<Guid, List<ResourceData>> resourcesByRegion,
+        Dictionary<Guid, List<ShortageAreaData>> shortageAreasByRegion,
+        Dictionary<Guid, List<WaterSignalData>> waterSignalsByRegion)
     {
         // Collect alerts from all descendant regions
         var alerts = CollectFromDescendants(alertsByRegion, descendantIds);
         var news = CollectFromDescendants(newsByRegion, descendantIds);
         var prevention = CollectFromDescendants(preventionByRegion, descendantIds);
         var resources = CollectFromDescendants(resourcesByRegion, descendantIds);
+        var shortageAreas = CollectFromDescendants(shortageAreasByRegion, descendantIds);
+        var waterSignals = CollectFromDescendants(waterSignalsByRegion, descendantIds);
 
-        // Top alerts: exclude community health indicators (PLACES data) — those are
-        // population stats, not disease outbreak alerts. Sort by severity then date.
-        var topAlerts = alerts
+        // Top alerts: prefer non-community-health alerts, but fall back to community
+        // health indicators when that is all the region has so county pages do not
+        // show "published alerts" with an empty alert list.
+        var preferredAlerts = alerts
             .Where(a => !a.Disease.StartsWith("[Community Health]", StringComparison.Ordinal))
+            .ToList();
+        var alertPool = preferredAlerts.Count > 0 ? preferredAlerts : alerts;
+
+        var topAlerts = alertPool
             .OrderByDescending(a => a.Severity)
             .ThenByDescending(a => a.SourceDate)
             .Take(config.TopAlertsCount)
@@ -152,6 +165,48 @@ public sealed class RegionSnapshotBuilder(
             Total = resources.Count
         };
 
+        var accessSignals = shortageAreas
+            .GroupBy(s => s.ExternalSourceId)
+            .Select(g => g.OrderByDescending(x => x.SourceUpdatedAt).First())
+            .OrderByDescending(s => s.HpsaScore ?? 0)
+            .ThenBy(s => s.Discipline)
+            .Take(4)
+            .Select(s => new SnapshotAccessSignalSummary
+            {
+                DesignationId = s.DesignationId,
+                AreaName = s.AreaName,
+                Discipline = s.Discipline,
+                DesignationType = s.DesignationType,
+                Status = s.Status,
+                PopulationGroup = s.PopulationGroup,
+                HpsaScore = s.HpsaScore,
+                PopulationToProviderRatio = s.PopulationToProviderRatio,
+                SourceUpdatedAt = s.SourceUpdatedAt
+            })
+            .ToList();
+
+        var environmentalSignals = waterSignals
+            .Where(s => s.IsOpen)
+            .GroupBy(s => s.ExternalSourceId)
+            .Select(g => g.OrderByDescending(x => x.SourceUpdatedAt ?? x.IdentifiedAt).First())
+            .OrderByDescending(s => s.PopulationServed ?? 0)
+            .ThenByDescending(s => s.IdentifiedAt)
+            .Take(4)
+            .Select(s => new SnapshotEnvironmentalSignalSummary
+            {
+                ViolationId = s.ViolationId,
+                WaterSystemName = s.WaterSystemName,
+                ViolationCategory = s.ViolationCategory,
+                RuleName = s.RuleName,
+                ContaminantName = s.ContaminantName,
+                Summary = s.Summary,
+                IsOpen = s.IsOpen,
+                PopulationServed = s.PopulationServed,
+                IdentifiedAt = s.IdentifiedAt,
+                SourceUpdatedAt = s.SourceUpdatedAt
+            })
+            .ToList();
+
         // Prevention highlights: most recently created
         var preventionHighlights = prevention
             .OrderByDescending(p => p.CreatedAt)
@@ -186,6 +241,8 @@ public sealed class RegionSnapshotBuilder(
             TopAlertsJson = JsonSerializer.Serialize(topAlerts, JsonOptions),
             TrendHighlightsJson = JsonSerializer.Serialize(trendHighlights, JsonOptions),
             ResourceCountsJson = JsonSerializer.Serialize(resourceCounts, JsonOptions),
+            AccessSignalsJson = JsonSerializer.Serialize(accessSignals, JsonOptions),
+            EnvironmentalSignalsJson = JsonSerializer.Serialize(environmentalSignals, JsonOptions),
             PreventionHighlightsJson = JsonSerializer.Serialize(preventionHighlights, JsonOptions),
             NewsHighlightsJson = JsonSerializer.Serialize(newsHighlights, JsonOptions)
         };
@@ -344,6 +401,56 @@ public sealed class RegionSnapshotBuilder(
             .ToDictionary(g => g.Key, g => g.ToList());
     }
 
+    private async Task<Dictionary<Guid, List<ShortageAreaData>>> LoadShortageAreasByRegionAsync(CancellationToken ct)
+    {
+        var designations = await dbContext.ShortageAreaDesignations
+            .AsNoTracking()
+            .Select(d => new ShortageAreaData
+            {
+                DesignationId = d.Id,
+                RegionId = d.RegionId,
+                ExternalSourceId = d.ExternalSourceId,
+                AreaName = d.AreaName,
+                Discipline = d.Discipline,
+                DesignationType = d.DesignationType,
+                Status = d.Status,
+                PopulationGroup = d.PopulationGroup,
+                HpsaScore = d.HpsaScore,
+                PopulationToProviderRatio = d.PopulationToProviderRatio,
+                SourceUpdatedAt = d.SourceUpdatedAt
+            })
+            .ToListAsync(ct);
+
+        return designations.GroupBy(d => d.RegionId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+    }
+
+    private async Task<Dictionary<Guid, List<WaterSignalData>>> LoadWaterSignalsByRegionAsync(CancellationToken ct)
+    {
+        var violations = await dbContext.WaterSystemViolations
+            .AsNoTracking()
+            .Include(v => v.WaterSystem)
+            .Select(v => new WaterSignalData
+            {
+                ViolationId = v.Id,
+                RegionId = v.RegionId,
+                ExternalSourceId = v.ExternalSourceId,
+                WaterSystemName = v.WaterSystem.Name,
+                ViolationCategory = v.ViolationCategory,
+                RuleName = v.RuleName,
+                ContaminantName = v.ContaminantName,
+                Summary = v.Summary,
+                IsOpen = v.IsOpen,
+                PopulationServed = v.WaterSystem.PopulationServed,
+                IdentifiedAt = v.IdentifiedAt,
+                SourceUpdatedAt = v.SourceUpdatedAt
+            })
+            .ToListAsync(ct);
+
+        return violations.GroupBy(v => v.RegionId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+    }
+
     private sealed class AlertData
     {
         public Guid AlertId { get; init; }
@@ -387,5 +494,36 @@ public sealed class RegionSnapshotBuilder(
     {
         public Guid RegionId { get; init; }
         public ResourceType Type { get; init; }
+    }
+
+    private sealed class ShortageAreaData
+    {
+        public Guid DesignationId { get; init; }
+        public Guid RegionId { get; init; }
+        public string ExternalSourceId { get; init; } = string.Empty;
+        public string AreaName { get; init; } = string.Empty;
+        public string Discipline { get; init; } = string.Empty;
+        public string DesignationType { get; init; } = string.Empty;
+        public string Status { get; init; } = string.Empty;
+        public string? PopulationGroup { get; init; }
+        public int? HpsaScore { get; init; }
+        public decimal? PopulationToProviderRatio { get; init; }
+        public DateTime? SourceUpdatedAt { get; init; }
+    }
+
+    private sealed class WaterSignalData
+    {
+        public Guid ViolationId { get; init; }
+        public Guid RegionId { get; init; }
+        public string ExternalSourceId { get; init; } = string.Empty;
+        public string WaterSystemName { get; init; } = string.Empty;
+        public string ViolationCategory { get; init; } = string.Empty;
+        public string RuleName { get; init; } = string.Empty;
+        public string? ContaminantName { get; init; }
+        public string Summary { get; init; } = string.Empty;
+        public bool IsOpen { get; init; }
+        public int? PopulationServed { get; init; }
+        public DateTime? IdentifiedAt { get; init; }
+        public DateTime? SourceUpdatedAt { get; init; }
     }
 }

--- a/src/backend/SniffleReport.Api/StaticExport/StaticSiteExporter.cs
+++ b/src/backend/SniffleReport.Api/StaticExport/StaticSiteExporter.cs
@@ -157,6 +157,8 @@ public sealed class StaticSiteExporter(AppDbContext dbContext, ILogger<StaticSit
                 topAlerts = JsonSerializer.Deserialize<List<SnapshotAlertSummary>>(snapshot.TopAlertsJson, JsonOptions) ?? [],
                 trendHighlights = JsonSerializer.Deserialize<List<SnapshotTrendHighlight>>(snapshot.TrendHighlightsJson, JsonOptions) ?? [],
                 resourceCounts = JsonSerializer.Deserialize<SnapshotResourceCounts>(snapshot.ResourceCountsJson, JsonOptions) ?? new(),
+                accessSignals = JsonSerializer.Deserialize<List<SnapshotAccessSignalSummary>>(snapshot.AccessSignalsJson, JsonOptions) ?? [],
+                environmentalSignals = JsonSerializer.Deserialize<List<SnapshotEnvironmentalSignalSummary>>(snapshot.EnvironmentalSignalsJson, JsonOptions) ?? [],
                 nearbyResources,
                 preventionHighlights = JsonSerializer.Deserialize<List<SnapshotPreventionSummary>>(snapshot.PreventionHighlightsJson, JsonOptions) ?? [],
                 newsHighlights = JsonSerializer.Deserialize<List<SnapshotNewsSummary>>(snapshot.NewsHighlightsJson, JsonOptions) ?? []
@@ -173,19 +175,29 @@ public sealed class StaticSiteExporter(AppDbContext dbContext, ILogger<StaticSit
             .GroupBy(log => log.FeedSourceId)
             .Select(g => g.OrderByDescending(log => log.StartedAt).First())
             .ToDictionaryAsync(log => log.FeedSourceId, ct);
+        var latestIngests = await dbContext.IngestedRecords
+            .AsNoTracking()
+            .GroupBy(record => record.FeedSourceId)
+            .Select(g => new
+            {
+                FeedSourceId = g.Key,
+                LastIngestedAt = g.Max(record => record.LastIngestedAt)
+            })
+            .ToDictionaryAsync(x => x.FeedSourceId, x => (DateTime?)x.LastIngestedAt, ct);
 
         var feedStatus = feeds
         .Where(f => f.IsEnabled)
         .Select(f =>
         {
             latestSyncs.TryGetValue(f.Id, out var lastSync);
+            latestIngests.TryGetValue(f.Id, out var lastIngestedAt);
             return new
             {
                 name = f.Name,
                 type = f.Type.ToString(),
                 isEnabled = f.IsEnabled,
                 lastSyncStatus = f.LastSyncStatus.ToString(),
-                lastSyncCompletedAt = f.LastSyncCompletedAt,
+                lastSyncCompletedAt = f.LastSyncCompletedAt ?? lastIngestedAt ?? lastSync?.CompletedAt ?? lastSync?.StartedAt,
                 lastRecordsCreated = lastSync?.RecordsCreated,
                 lastRecordsFetched = lastSync?.RecordsFetched
             };

--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -405,6 +405,21 @@
   gap: 0.625rem;
 }
 
+.dashboard-signal-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+}
+
+.dashboard-signal-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.875rem 1rem;
+  background: color-mix(in srgb, var(--paper-deep) 82%, #d7efe3 18%);
+  border-radius: var(--radius-md);
+}
+
 .dashboard-alert-card {
   display: flex;
   flex-direction: column;
@@ -451,6 +466,14 @@
   font-size: 0.8125rem;
   line-height: 1.45;
   color: var(--ink-soft);
+}
+
+.dashboard-alert-card__indicator {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent);
 }
 
 .dashboard-alert-card__trend {
@@ -864,6 +887,54 @@
 .status-sync--partial { background: var(--warning-bg); color: var(--warning); }
 .status-sync--failed { background: var(--danger-bg); color: var(--danger); }
 .status-sync--never { background: var(--paper-deep); color: var(--ink-faint); }
+
+.status-feed-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.9rem;
+}
+
+.status-feed-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  background: var(--paper-deep);
+}
+
+.status-feed-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.status-feed-card__type {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.status-feed-card p {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: var(--ink-soft);
+}
+
+.status-feed-card__updated {
+  font-size: 0.8125rem;
+  color: var(--ink-faint);
+}
+
+.status-feed-card__metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
 
 /* ── Error State ──────────────────────────────────── */
 

--- a/src/frontend/src/api/types.ts
+++ b/src/frontend/src/api/types.ts
@@ -410,6 +410,31 @@ export const snapshotResourceCountsSchema = z.object({
   total: z.number().int().nonnegative(),
 })
 
+export const snapshotAccessSignalSummarySchema = z.object({
+  designationId: guidSchema,
+  areaName: z.string().min(1),
+  discipline: z.string().min(1),
+  designationType: z.string().min(1),
+  status: z.string().min(1),
+  populationGroup: z.string().nullable(),
+  hpsaScore: z.number().int().nullable(),
+  populationToProviderRatio: z.number().nullable(),
+  sourceUpdatedAt: isoDateTimeSchema.nullable(),
+})
+
+export const snapshotEnvironmentalSignalSummarySchema = z.object({
+  violationId: guidSchema,
+  waterSystemName: z.string().min(1),
+  violationCategory: z.string().min(1),
+  ruleName: z.string().min(1),
+  contaminantName: z.string().nullable(),
+  summary: z.string().min(1),
+  isOpen: z.boolean(),
+  populationServed: z.number().int().nullable(),
+  identifiedAt: isoDateTimeSchema.nullable(),
+  sourceUpdatedAt: isoDateTimeSchema.nullable(),
+})
+
 export const snapshotPreventionSummarySchema = z.object({
   guideId: guidSchema,
   disease: z.string().min(1),
@@ -431,6 +456,8 @@ export const regionDashboardSchema = z.object({
   topAlerts: z.array(snapshotAlertSummarySchema),
   trendHighlights: z.array(snapshotTrendHighlightSchema),
   resourceCounts: snapshotResourceCountsSchema,
+  accessSignals: z.array(snapshotAccessSignalSummarySchema),
+  environmentalSignals: z.array(snapshotEnvironmentalSignalSummarySchema),
   preventionHighlights: z.array(snapshotPreventionSummarySchema),
   newsHighlights: z.array(snapshotNewsSummarySchema),
 })
@@ -438,6 +465,8 @@ export const regionDashboardSchema = z.object({
 export type SnapshotAlertSummary = z.infer<typeof snapshotAlertSummarySchema>
 export type SnapshotTrendHighlight = z.infer<typeof snapshotTrendHighlightSchema>
 export type SnapshotResourceCounts = z.infer<typeof snapshotResourceCountsSchema>
+export type SnapshotAccessSignalSummary = z.infer<typeof snapshotAccessSignalSummarySchema>
+export type SnapshotEnvironmentalSignalSummary = z.infer<typeof snapshotEnvironmentalSignalSummarySchema>
 export type SnapshotPreventionSummary = z.infer<typeof snapshotPreventionSummarySchema>
 export type SnapshotNewsSummary = z.infer<typeof snapshotNewsSummarySchema>
 export type RegionDashboard = z.infer<typeof regionDashboardSchema>

--- a/src/frontend/src/hooks/useStaticData.ts
+++ b/src/frontend/src/hooks/useStaticData.ts
@@ -6,6 +6,8 @@ import {
   snapshotAlertSummarySchema,
   snapshotTrendHighlightSchema,
   snapshotResourceCountsSchema,
+  snapshotAccessSignalSummarySchema,
+  snapshotEnvironmentalSignalSummarySchema,
   snapshotPreventionSummarySchema,
   snapshotNewsSummarySchema,
   resourceTypeSchema,
@@ -70,6 +72,8 @@ const staticDashboardSchema = z.object({
   topAlerts: z.array(snapshotAlertSummarySchema),
   trendHighlights: z.array(snapshotTrendHighlightSchema),
   resourceCounts: snapshotResourceCountsSchema,
+  accessSignals: z.array(snapshotAccessSignalSummarySchema),
+  environmentalSignals: z.array(snapshotEnvironmentalSignalSummarySchema),
   nearbyResources: z.array(
     z.object({
       id: z.string().uuid(),

--- a/src/frontend/src/pages/HomePage.tsx
+++ b/src/frontend/src/pages/HomePage.tsx
@@ -22,8 +22,8 @@ export function HomePage() {
           <h1>Community health data for every US county</h1>
           <p>
             Regional health trends, disease surveillance, local clinics and pharmacies,
-            prevention guidance, and drug safety alerts — sourced from CDC, FDA, and CMS.
-            Updated automatically from 12 public data feeds.
+            prevention guidance, and drug safety alerts sourced from the CDC, FDA, and CMS.
+            The site updates automatically from 12 public data feeds.
           </p>
           <div className="page-badges">
             <span className="page-badge">50 states + DC</span>

--- a/src/frontend/src/pages/RegionalDashboardPage.test.tsx
+++ b/src/frontend/src/pages/RegionalDashboardPage.test.tsx
@@ -1,13 +1,151 @@
 import { render, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { RegionalDashboardPage } from './RegionalDashboardPage'
 
+let mockDashboard = {
+  regionId: '8fb8cb1d-6622-4c13-a0b8-f6ccebc5454b',
+  computedAt: '2026-03-21T12:00:00Z',
+  publishedAlertCount: 2,
+  regionName: 'Travis County',
+  state: 'TX',
+  regionType: 'County',
+  parentState: 'TX',
+  parentName: 'Texas',
+  topAlerts: [
+    {
+      alertId: '1f1ecb6b-c7dc-4142-bdc7-bff8cb6c57e4',
+      disease: 'Influenza A',
+      title: 'Seasonal flu activity is elevated',
+      summary: 'Emergency department visits and lab-confirmed cases are increasing across the county.',
+      severity: 'High',
+      caseCount: 123,
+      sourceAttribution: 'County health department surveillance',
+      sourceDate: '2026-03-20T00:00:00Z',
+      previousCaseCount: 77,
+      wowChangePercent: 59.7,
+      previousSourceDate: '2026-03-13T00:00:00Z',
+    },
+    {
+      alertId: '951bfbd1-3074-44ed-a753-7273c8105e2f',
+      disease: 'Influenza A',
+      title: 'Seasonal flu activity is elevated',
+      summary: 'Emergency department visits and lab-confirmed cases are increasing across the county.',
+      severity: 'High',
+      caseCount: 123,
+      sourceAttribution: 'County health department surveillance',
+      sourceDate: '2026-03-19T00:00:00Z',
+      previousCaseCount: null,
+      wowChangePercent: null,
+      previousSourceDate: null,
+    },
+    {
+      alertId: 'cdf50eb8-cf20-4322-aa52-6e42c342f30d',
+      disease: 'RSV',
+      title: 'Pediatric RSV remains active',
+      summary: 'RSV activity remains elevated for young children and urgent care visits are up.',
+      severity: 'Moderate',
+      caseCount: 58,
+      sourceAttribution: 'Regional pediatric hospital network',
+      sourceDate: '2026-03-18T00:00:00Z',
+      previousCaseCount: null,
+      wowChangePercent: null,
+      previousSourceDate: null,
+    },
+  ],
+  trendHighlights: [
+    {
+      alertId: '1f1ecb6b-c7dc-4142-bdc7-bff8cb6c57e4',
+      disease: 'Influenza A',
+      latestCaseCount: 123,
+      previousCaseCount: 77,
+      wowChangePercent: 59.7,
+      latestDate: '2026-03-20T00:00:00Z',
+    },
+  ],
+  resourceCounts: {
+    clinic: 12,
+    pharmacy: 8,
+    vaccinationSite: 3,
+    hospital: 1,
+    total: 24,
+  },
+  accessSignals: [
+    {
+      designationId: '3f75bb6a-d4d1-4dc5-9f23-cf79278ca73d',
+      areaName: 'Travis County primary care service area',
+      discipline: 'Primary Care',
+      designationType: 'Geographic area',
+      status: 'Designated',
+      populationGroup: null,
+      hpsaScore: 14,
+      populationToProviderRatio: 3550.2,
+      sourceUpdatedAt: '2026-03-11T00:00:00Z',
+    },
+  ],
+  environmentalSignals: [
+    {
+      violationId: 'fce8d336-e7f2-442b-9ed1-71577f1eff4d',
+      waterSystemName: 'Central Travis Water Authority',
+      violationCategory: 'Monitoring and reporting',
+      ruleName: 'Lead and Copper Rule',
+      contaminantName: 'Lead',
+      summary: 'Open monitoring and reporting violation under the Lead and Copper Rule for a community water system serving central Travis County.',
+      isOpen: true,
+      populationServed: 182000,
+      identifiedAt: '2026-02-18T00:00:00Z',
+      sourceUpdatedAt: '2026-03-21T00:00:00Z',
+    },
+  ],
+  nearbyResources: [
+    {
+      id: '917cc0d1-9ea0-4f11-b0bb-0f1894b60f1f',
+      regionId: '8fb8cb1d-6622-4c13-a0b8-f6ccebc5454b',
+      name: 'Travis Pharmacy',
+      type: 'Pharmacy',
+      address: '123 Congress Ave, Austin, TX',
+      phone: '(512) 555-0110',
+      website: 'https://example.org/pharmacy',
+    },
+  ],
+  preventionHighlights: [
+    {
+      guideId: 'b7e9c781-13fe-4a0e-bb73-c5f3d063a213',
+      disease: 'Influenza A',
+      title: 'Flu shot options',
+      hasCostTiers: true,
+    },
+  ],
+  newsHighlights: [],
+}
+
 vi.mock('../hooks/useStaticData', () => ({
   useStaticDashboard: () => ({
-    data: {
+    data: mockDashboard,
+    isLoading: false,
+    isError: false,
+  }),
+}))
+
+function renderPage(initialEntry: string) {
+  const queryClient = new QueryClient()
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/region/:regionId" element={<RegionalDashboardPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('RegionalDashboardPage', () => {
+  beforeEach(() => {
+    mockDashboard = {
       regionId: '8fb8cb1d-6622-4c13-a0b8-f6ccebc5454b',
       computedAt: '2026-03-21T12:00:00Z',
       publishedAlertCount: 2,
@@ -39,6 +177,9 @@ vi.mock('../hooks/useStaticData', () => ({
           caseCount: 123,
           sourceAttribution: 'County health department surveillance',
           sourceDate: '2026-03-19T00:00:00Z',
+          previousCaseCount: null,
+          wowChangePercent: null,
+          previousSourceDate: null,
         },
         {
           alertId: 'cdf50eb8-cf20-4322-aa52-6e42c342f30d',
@@ -49,6 +190,9 @@ vi.mock('../hooks/useStaticData', () => ({
           caseCount: 58,
           sourceAttribution: 'Regional pediatric hospital network',
           sourceDate: '2026-03-18T00:00:00Z',
+          previousCaseCount: null,
+          wowChangePercent: null,
+          previousSourceDate: null,
         },
       ],
       trendHighlights: [
@@ -68,6 +212,33 @@ vi.mock('../hooks/useStaticData', () => ({
         hospital: 1,
         total: 24,
       },
+      accessSignals: [
+        {
+          designationId: '3f75bb6a-d4d1-4dc5-9f23-cf79278ca73d',
+          areaName: 'Travis County primary care service area',
+          discipline: 'Primary Care',
+          designationType: 'Geographic area',
+          status: 'Designated',
+          populationGroup: null,
+          hpsaScore: 14,
+          populationToProviderRatio: 3550.2,
+          sourceUpdatedAt: '2026-03-11T00:00:00Z',
+        },
+      ],
+      environmentalSignals: [
+        {
+          violationId: 'fce8d336-e7f2-442b-9ed1-71577f1eff4d',
+          waterSystemName: 'Central Travis Water Authority',
+          violationCategory: 'Monitoring and reporting',
+          ruleName: 'Lead and Copper Rule',
+          contaminantName: 'Lead',
+          summary: 'Open monitoring and reporting violation under the Lead and Copper Rule for a community water system serving central Travis County.',
+          isOpen: true,
+          populationServed: 182000,
+          identifiedAt: '2026-02-18T00:00:00Z',
+          sourceUpdatedAt: '2026-03-21T00:00:00Z',
+        },
+      ],
       nearbyResources: [
         {
           id: '917cc0d1-9ea0-4f11-b0bb-0f1894b60f1f',
@@ -88,25 +259,11 @@ vi.mock('../hooks/useStaticData', () => ({
         },
       ],
       newsHighlights: [],
-    },
-    isLoading: false,
-    isError: false,
-  }),
-}))
+    }
+  })
 
-describe('RegionalDashboardPage', () => {
   it('renders dashboard summary sections from snapshot', () => {
-    const queryClient = new QueryClient()
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={['/region/8fb8cb1d-6622-4c13-a0b8-f6ccebc5454b']}>
-          <Routes>
-            <Route path="/region/:regionId" element={<RegionalDashboardPage />} />
-          </Routes>
-        </MemoryRouter>
-      </QueryClientProvider>,
-    )
+    renderPage('/region/8fb8cb1d-6622-4c13-a0b8-f6ccebc5454b')
 
     expect(screen.getByRole('heading', { name: 'Travis County, TX' })).toBeInTheDocument()
     expect(screen.getByText(/travis pharmacy/i)).toBeInTheDocument()
@@ -117,12 +274,52 @@ describe('RegionalDashboardPage', () => {
     expect(screen.getByText(/77 previous cases · \+59.7% WoW/i)).toBeInTheDocument()
     expect(screen.getByText(/2 updates/i)).toBeInTheDocument()
     expect(screen.getByText(/county health department surveillance · mar 18-20, 2026/i)).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /back to texas/i })).toHaveAttribute(
-      'href',
-      '/states/TX',
-    )
+    expect(screen.getByRole('link', { name: /back to texas/i })).toHaveAttribute('href', '/states/TX')
     expect(screen.getByText(/seasonal flu activity is elevated/i)).toBeInTheDocument()
     expect(screen.getAllByText(/seasonal flu activity is elevated/i)).toHaveLength(1)
     expect(screen.getByText(/123 cases \(\+59.7% WoW\)/i)).toBeInTheDocument()
+    expect(screen.getByText(/hpsa score 14/i)).toBeInTheDocument()
+    expect(screen.getByText(/central travis water authority/i)).toBeInTheDocument()
+    expect(screen.getByText(/182,000 served/i)).toBeInTheDocument()
+  })
+
+  it('renders community health alerts as indicators instead of outbreak cases', () => {
+    mockDashboard = {
+      ...mockDashboard,
+      regionId: '560440d4-2f60-4880-a8fa-b2299aeca2f4',
+      regionName: 'Arkansas County',
+      state: 'AR',
+      parentState: 'AR',
+      parentName: 'Arkansas',
+      publishedAlertCount: 23,
+      topAlerts: [
+        {
+          alertId: 'bd992032-7cf1-4c2c-8a75-6a7ccd9064ee',
+          disease: '[Community Health] Visits to doctor for routine checkup within the past year among adults',
+          title: 'Visits to doctor for routine checkup within the past year among adults: 78.1% (age-adjusted)',
+          summary: 'Prevention - Visits to doctor for routine checkup within the past year among adults. Age-adjusted prevalence: 78.1%.',
+          severity: 'Low',
+          caseCount: 78,
+          sourceAttribution: 'CDC PLACES County Health',
+          sourceDate: '2026-04-05T19:25:10.72226Z',
+          previousCaseCount: null,
+          wowChangePercent: null,
+          previousSourceDate: null,
+        },
+      ],
+      trendHighlights: [],
+      accessSignals: [],
+      environmentalSignals: [],
+      nearbyResources: [],
+      preventionHighlights: [],
+      newsHighlights: [],
+    }
+
+    renderPage('/region/560440d4-2f60-4880-a8fa-b2299aeca2f4')
+
+    expect(screen.getByText(/78.1% prevalence/i)).toBeInTheDocument()
+    expect(screen.getByText(/community health indicator/i)).toBeInTheDocument()
+    expect(screen.getByText(/age-adjusted prevalence: 78.1%/i)).toBeInTheDocument()
+    expect(screen.getByText(/^Visits to doctor for routine checkup within the past year among adults$/i)).toBeInTheDocument()
   })
 })

--- a/src/frontend/src/pages/RegionalDashboardPage.tsx
+++ b/src/frontend/src/pages/RegionalDashboardPage.tsx
@@ -21,6 +21,10 @@ function formatDate(date: string) {
   }).format(new Date(date))
 }
 
+function formatNumber(value: number) {
+  return new Intl.NumberFormat('en-US').format(value)
+}
+
 function formatDateRange(startDate: string, endDate: string) {
   const start = new Date(startDate)
   const end = new Date(endDate)
@@ -85,6 +89,22 @@ type DisplayAlert = DashboardAlert & {
   latestSourceDate: string
   earliestSourceDate: string
   occurrenceCount: number
+}
+
+function isCommunityHealthAlert(alert: { disease: string }) {
+  return alert.disease.startsWith('[Community Health]')
+}
+
+function getDisplayDiseaseName(disease: string) {
+  return disease.replace(/^\[Community Health\]\s*/, '').trim()
+}
+
+function buildAlertMetricLabel(alert: { caseCount: number; disease: string }) {
+  if (isCommunityHealthAlert(alert)) {
+    return `${alert.caseCount}% indicator`
+  }
+
+  return `${alert.caseCount} cases`
 }
 
 function createAlertGroupKey(alert: DashboardAlert) {
@@ -161,6 +181,37 @@ function buildDisplayAlertMeta(alert: DisplayAlert) {
   return `${sourceLabel} · ${dateLabel}`
 }
 
+function buildAlertHeading(alert: DisplayAlert) {
+  if (!isCommunityHealthAlert(alert)) {
+    return alert.title
+  }
+
+  return getDisplayDiseaseName(alert.disease)
+}
+
+function buildAlertTypeLabel(alert: DisplayAlert) {
+  if (!isCommunityHealthAlert(alert)) {
+    return null
+  }
+
+  return 'Community health indicator'
+}
+
+function buildCommunityHealthSummary(alert: DisplayAlert) {
+  return alert.summary
+}
+
+function buildCommunityHealthMetricLabel(alert: DisplayAlert) {
+  const percentageMatch = alert.title.match(/:\s*([0-9.]+)%/)
+  const displayValue = percentageMatch ? `${percentageMatch[1]}%` : `${alert.caseCount}%`
+
+  if (/prevalence/i.test(alert.summary)) {
+    return `${displayValue} prevalence`
+  }
+
+  return `${displayValue} rate`
+}
+
 export function RegionalDashboardPage() {
   const { regionId } = useParams<{ regionId: string }>()
   const dashboardQuery = useStaticDashboard(regionId ?? '')
@@ -191,6 +242,8 @@ export function RegionalDashboardPage() {
 
   const resourceCounts = dashboard?.resourceCounts
   const nearbyResources = dashboard?.nearbyResources ?? []
+  const accessSignals = dashboard?.accessSignals ?? []
+  const environmentalSignals = dashboard?.environmentalSignals ?? []
   const resourceParts = resourceCounts
     ? [
         resourceCounts.clinic > 0 ? `${resourceCounts.clinic} clinics` : null,
@@ -261,13 +314,20 @@ export function RegionalDashboardPage() {
                   <article className="dashboard-alert-card" key={alert.alertId}>
                     <div className="dashboard-alert-card__row">
                       <SeverityBadge severity={alert.severity as 'Low' | 'Moderate' | 'High' | 'Critical'} />
-                      <span className="dashboard-alert-card__cases">{alert.caseCount} cases</span>
+                      <span className="dashboard-alert-card__cases">
+                        {isCommunityHealthAlert(alert) ? buildCommunityHealthMetricLabel(alert) : buildAlertMetricLabel(alert)}
+                      </span>
                       {buildAlertOccurrencesLabel(alert) ? (
                         <span className="dashboard-alert-card__updates">{buildAlertOccurrencesLabel(alert)}</span>
                       ) : null}
                     </div>
-                    <strong>{alert.title}</strong>
-                    <p className="dashboard-alert-card__summary">{buildAlertSummary(alert)}</p>
+                    <strong>{buildAlertHeading(alert)}</strong>
+                    {buildAlertTypeLabel(alert) ? (
+                      <span className="dashboard-alert-card__indicator">{buildAlertTypeLabel(alert)}</span>
+                    ) : null}
+                    <p className="dashboard-alert-card__summary">
+                      {isCommunityHealthAlert(alert) ? buildCommunityHealthSummary(alert) : buildAlertSummary(alert)}
+                    </p>
                     {alert.previousCaseCount != null && alert.wowChangePercent != null ? (
                       <span className="dashboard-alert-card__trend">
                         {alert.previousCaseCount} previous cases · {formatAlertWowChange(alert.wowChangePercent)} WoW
@@ -313,6 +373,64 @@ export function RegionalDashboardPage() {
               </div>
             ) : (
               <p className="dashboard-empty">Trend data is not available for this region yet.</p>
+            )}
+          </section>
+
+          <section className="page-panel dashboard-card">
+            <div className="dashboard-card__header">
+              <div>
+                <span className="section-kicker">Access & safety</span>
+                <strong>Provider shortages and drinking water issues</strong>
+              </div>
+            </div>
+
+            {isLoading ? (
+              <div className="dashboard-skeleton-group" aria-hidden="true">
+                <div className="dashboard-skeleton dashboard-skeleton--line" />
+                <div className="dashboard-skeleton dashboard-skeleton--card" />
+              </div>
+            ) : accessSignals.length || environmentalSignals.length ? (
+              <div className="dashboard-signal-list">
+                {accessSignals.map((signal) => (
+                  <article className="dashboard-signal-card" key={signal.designationId}>
+                    <div className="dashboard-alert-card__row">
+                      <span className="page-badge">{signal.discipline}</span>
+                      {signal.hpsaScore != null ? (
+                        <span className="dashboard-alert-card__cases">HPSA score {signal.hpsaScore}</span>
+                      ) : null}
+                    </div>
+                    <strong>{signal.areaName}</strong>
+                    <span className="dashboard-alert-card__indicator">{signal.designationType}</span>
+                    <p className="dashboard-alert-card__summary">
+                      {signal.populationToProviderRatio != null
+                        ? `${signal.status}. Estimated population-to-provider ratio: ${signal.populationToProviderRatio.toLocaleString('en-US', { maximumFractionDigits: 1 })}.`
+                        : `${signal.status}. HRSA shortage-area designation for this region.`}
+                    </p>
+                    <span className="dashboard-alert-card__meta">
+                      HRSA HPSA{signal.sourceUpdatedAt ? ` · ${formatDate(signal.sourceUpdatedAt)}` : ''}
+                    </span>
+                  </article>
+                ))}
+                {environmentalSignals.map((signal) => (
+                  <article className="dashboard-signal-card" key={signal.violationId}>
+                    <div className="dashboard-alert-card__row">
+                      <span className="page-badge">Water safety</span>
+                      {signal.populationServed != null ? (
+                        <span className="dashboard-alert-card__cases">{formatNumber(signal.populationServed)} served</span>
+                      ) : null}
+                    </div>
+                    <strong>{signal.waterSystemName}</strong>
+                    <span className="dashboard-alert-card__indicator">{signal.violationCategory}</span>
+                    <p className="dashboard-alert-card__summary">{signal.summary}</p>
+                    <span className="dashboard-alert-card__meta">
+                      {signal.ruleName}
+                      {signal.identifiedAt ? ` · Open since ${formatDate(signal.identifiedAt)}` : ''}
+                    </span>
+                  </article>
+                ))}
+              </div>
+            ) : (
+              <p className="dashboard-empty">No provider-shortage or drinking-water safety signals for this region yet.</p>
             )}
           </section>
 

--- a/src/frontend/src/pages/StateBrowsePage.test.tsx
+++ b/src/frontend/src/pages/StateBrowsePage.test.tsx
@@ -101,6 +101,44 @@ vi.mock('../hooks/useStaticData', () => ({
         hospital: 205,
         total: 638,
       },
+      accessSignals: [
+        {
+          designationId: '0a4da3dd-f7cd-4778-b456-c215c5ff2d8a',
+          areaName: 'Philadelphia County mental health service area',
+          discipline: 'Mental Health',
+          designationType: 'Geographic area',
+          status: 'Designated',
+          populationGroup: null,
+          hpsaScore: 17,
+          populationToProviderRatio: 4280.4,
+          sourceUpdatedAt: '2026-03-29T00:00:00Z',
+        },
+        {
+          designationId: 'f7673426-ea21-40b2-9f78-f7d01c232916',
+          areaName: 'Rural northwest Pennsylvania primary care service area',
+          discipline: 'Primary Care',
+          designationType: 'Geographic area',
+          status: 'Designated',
+          populationGroup: null,
+          hpsaScore: 12,
+          populationToProviderRatio: 3010.2,
+          sourceUpdatedAt: '2026-03-25T00:00:00Z',
+        },
+      ],
+      environmentalSignals: [
+        {
+          violationId: 'b563a47d-d33d-4c12-9126-25df5f467d96',
+          waterSystemName: 'Philadelphia River Supply',
+          violationCategory: 'Maximum contaminant level',
+          ruleName: 'Total Trihalomethanes Rule',
+          contaminantName: 'Total trihalomethanes',
+          summary: 'Open maximum contaminant level violation for total trihalomethanes in a public water system serving Philadelphia County.',
+          isOpen: true,
+          populationServed: 346000,
+          identifiedAt: '2026-01-23T00:00:00Z',
+          sourceUpdatedAt: '2026-03-28T00:00:00Z',
+        },
+      ],
       nearbyResources: [],
       preventionHighlights: [],
       newsHighlights: [],
@@ -132,6 +170,12 @@ describe('StateBrowsePage', () => {
     expect(screen.getByText(/hepatitis c, chronic, probable/i)).toBeInTheDocument()
     expect(screen.getByText(/hepatitis c, perinatal, confirmed/i)).toBeInTheDocument()
     expect(screen.getByText(/influenza-associated pediatric mortality/i)).toBeInTheDocument()
+    expect(screen.getByText(/provider shortages and drinking water issues across the state/i)).toBeInTheDocument()
+    expect(screen.getByText(/mental health access constraints/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/1 shortage area/i)).toHaveLength(2)
+    expect(screen.getByText(/top hpsa score 17/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/maximum contaminant level/i)).toHaveLength(2)
+    expect(screen.getByText(/346,000 served/i)).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /chester county/i })).toHaveAttribute('href', '/region/4156a173-433d-4823-b48a-deb80c0842fa')
   })
 })

--- a/src/frontend/src/pages/StateBrowsePage.tsx
+++ b/src/frontend/src/pages/StateBrowsePage.tsx
@@ -37,6 +37,24 @@ type StatewidePattern = {
   diseases: string[]
 }
 
+type StatewideAccessPattern = {
+  key: string
+  discipline: string
+  designationCount: number
+  highestScore: number | null
+  latestDate: string | null
+  areas: string[]
+}
+
+type StatewideWaterPattern = {
+  key: string
+  violationCategory: string
+  violationCount: number
+  populationServed: number
+  latestDate: string | null
+  systems: string[]
+}
+
 function groupStatewideAlerts(topAlerts: RegionDashboard['topAlerts']) {
   const patterns = new Map<string, StatewidePattern>()
 
@@ -96,6 +114,89 @@ function buildPatternExamplesRemainder(pattern: StatewidePattern) {
   return pattern.diseaseCount - buildPatternExamples(pattern).length
 }
 
+function groupStatewideAccessSignals(accessSignals: RegionDashboard['accessSignals']) {
+  const patterns = new Map<string, StatewideAccessPattern>()
+
+  accessSignals.forEach((signal) => {
+    const key = signal.discipline.trim().toLowerCase()
+    const existing = patterns.get(key)
+
+    if (!existing) {
+      patterns.set(key, {
+        key,
+        discipline: signal.discipline,
+        designationCount: 1,
+        highestScore: signal.hpsaScore,
+        latestDate: signal.sourceUpdatedAt,
+        areas: [signal.areaName],
+      })
+      return
+    }
+
+    existing.designationCount += 1
+    existing.highestScore = existing.highestScore == null
+      ? signal.hpsaScore
+      : signal.hpsaScore == null
+        ? existing.highestScore
+        : Math.max(existing.highestScore, signal.hpsaScore)
+
+    if (signal.sourceUpdatedAt && (!existing.latestDate || new Date(signal.sourceUpdatedAt).getTime() > new Date(existing.latestDate).getTime())) {
+      existing.latestDate = signal.sourceUpdatedAt
+    }
+
+    if (!existing.areas.includes(signal.areaName)) {
+      existing.areas.push(signal.areaName)
+    }
+  })
+
+  return [...patterns.values()]
+    .sort((left, right) => {
+      if (right.designationCount !== left.designationCount) return right.designationCount - left.designationCount
+      return (right.highestScore ?? 0) - (left.highestScore ?? 0)
+    })
+    .slice(0, 3)
+}
+
+function groupStatewideWaterSignals(environmentalSignals: RegionDashboard['environmentalSignals']) {
+  const patterns = new Map<string, StatewideWaterPattern>()
+
+  environmentalSignals.forEach((signal) => {
+    const key = signal.violationCategory.trim().toLowerCase()
+    const existing = patterns.get(key)
+
+    if (!existing) {
+      patterns.set(key, {
+        key,
+        violationCategory: signal.violationCategory,
+        violationCount: 1,
+        populationServed: signal.populationServed ?? 0,
+        latestDate: signal.sourceUpdatedAt ?? signal.identifiedAt,
+        systems: [signal.waterSystemName],
+      })
+      return
+    }
+
+    existing.violationCount += 1
+    existing.populationServed += signal.populationServed ?? 0
+
+    const signalDate = signal.sourceUpdatedAt ?? signal.identifiedAt
+    if (signalDate && (!existing.latestDate || new Date(signalDate).getTime() > new Date(existing.latestDate).getTime())) {
+      existing.latestDate = signalDate
+    }
+
+    if (!existing.systems.includes(signal.waterSystemName)) {
+      existing.systems.push(signal.waterSystemName)
+    }
+  })
+
+  return [...patterns.values()]
+    .sort((left, right) => {
+      if (right.populationServed !== left.populationServed) return right.populationServed - left.populationServed
+      return right.violationCount - left.violationCount
+    })
+    .slice(0, 3)
+}
+
 export function StateBrowsePage() {
   const { stateCode } = useParams<{ stateCode: string }>()
   const stateQuery = useStateDetail(stateCode ?? '')
@@ -122,6 +223,16 @@ export function StateBrowsePage() {
   const statewidePatterns = useMemo(() => {
     if (!stateDashboardQuery.data) return []
     return groupStatewideAlerts(stateDashboardQuery.data.topAlerts)
+  }, [stateDashboardQuery.data])
+
+  const statewideAccessPatterns = useMemo(() => {
+    if (!stateDashboardQuery.data) return []
+    return groupStatewideAccessSignals(stateDashboardQuery.data.accessSignals)
+  }, [stateDashboardQuery.data])
+
+  const statewideWaterPatterns = useMemo(() => {
+    if (!stateDashboardQuery.data) return []
+    return groupStatewideWaterSignals(stateDashboardQuery.data.environmentalSignals)
   }, [stateDashboardQuery.data])
 
   function toggleSort(key: SortKey) {
@@ -234,6 +345,84 @@ export function StateBrowsePage() {
                   </div>
                   <span className="statewide-pattern-card__meta">
                     Updated {formatDate(pattern.latestDate)}
+                  </span>
+                </article>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {statewideAccessPatterns.length || statewideWaterPatterns.length ? (
+          <section className="page-panel">
+            <div className="dashboard-card__header">
+              <div>
+                <span className="section-kicker">Statewide access and safety</span>
+                <strong>Provider shortages and drinking water issues across the state</strong>
+              </div>
+            </div>
+            <div className="statewide-pattern-list">
+              {statewideAccessPatterns.map((pattern) => (
+                <article className="statewide-pattern-card" key={pattern.key}>
+                  <div className="statewide-pattern-card__header">
+                    <span className="page-badge">{pattern.discipline}</span>
+                    <span className="state-alert-pill">
+                      {pattern.designationCount} shortage area{pattern.designationCount === 1 ? '' : 's'}
+                    </span>
+                  </div>
+                  <strong>{pattern.discipline} access constraints</strong>
+                  <div className="statewide-pattern-card__stats">
+                    {pattern.highestScore != null ? (
+                      <span className="page-badge">Top HPSA score {pattern.highestScore}</span>
+                    ) : null}
+                    <span className="page-badge">{pattern.areas.length} areas</span>
+                  </div>
+                  <p>
+                    HRSA currently designates {pattern.designationCount} {pattern.discipline.toLowerCase()} shortage area{pattern.designationCount === 1 ? '' : 's'} in this statewide snapshot.
+                  </p>
+                  <div className="statewide-pattern-card__examples">
+                    {pattern.areas.slice(0, 3).map((area) => (
+                      <span className="statewide-pattern-card__example" key={area}>{area}</span>
+                    ))}
+                    {pattern.areas.length > 3 ? (
+                      <span className="statewide-pattern-card__example statewide-pattern-card__example--more">
+                        +{pattern.areas.length - 3} more
+                      </span>
+                    ) : null}
+                  </div>
+                  <span className="statewide-pattern-card__meta">
+                    HRSA HPSA{pattern.latestDate ? ` · Updated ${formatDate(pattern.latestDate)}` : ''}
+                  </span>
+                </article>
+              ))}
+
+              {statewideWaterPatterns.map((pattern) => (
+                <article className="statewide-pattern-card" key={pattern.key}>
+                  <div className="statewide-pattern-card__header">
+                    <span className="page-badge">Water safety</span>
+                    <span className="state-alert-pill">
+                      {pattern.violationCount} open issue{pattern.violationCount === 1 ? '' : 's'}
+                    </span>
+                  </div>
+                  <strong>{pattern.violationCategory}</strong>
+                  <div className="statewide-pattern-card__stats">
+                    <span className="page-badge">{pattern.populationServed.toLocaleString()} served</span>
+                    <span className="page-badge">{pattern.systems.length} systems</span>
+                  </div>
+                  <p>
+                    EPA SDWIS shows {pattern.violationCount} open {pattern.violationCategory.toLowerCase()} issue{pattern.violationCount === 1 ? '' : 's'} in the current statewide snapshot.
+                  </p>
+                  <div className="statewide-pattern-card__examples">
+                    {pattern.systems.slice(0, 3).map((system) => (
+                      <span className="statewide-pattern-card__example" key={system}>{system}</span>
+                    ))}
+                    {pattern.systems.length > 3 ? (
+                      <span className="statewide-pattern-card__example statewide-pattern-card__example--more">
+                        +{pattern.systems.length - 3} more
+                      </span>
+                    ) : null}
+                  </div>
+                  <span className="statewide-pattern-card__meta">
+                    EPA SDWIS{pattern.latestDate ? ` · Updated ${formatDate(pattern.latestDate)}` : ''}
                   </span>
                 </article>
               ))}

--- a/src/frontend/src/pages/StatusPage.tsx
+++ b/src/frontend/src/pages/StatusPage.tsx
@@ -24,13 +24,68 @@ function formatDateTime(date: string | null) {
   }).format(new Date(date))
 }
 
-function syncStatusClass(status: string | null): string {
-  switch (status) {
-    case 'Success': return 'status-sync--success'
-    case 'PartialSuccess': return 'status-sync--partial'
-    case 'Failed': return 'status-sync--failed'
-    case 'NeverRun': return 'status-sync--never'
-    default: return ''
+function getFeedStatus(feed: {
+  lastSyncStatus: string | null
+  lastSyncCompletedAt: string | null
+  lastRecordsFetched: number | null
+}) {
+  if (feed.lastSyncStatus === 'Failed') {
+    return {
+      label: 'Needs attention',
+      className: 'status-sync--failed',
+      detail: 'Latest refresh failed for this source.',
+    }
+  }
+
+  if (feed.lastSyncStatus === 'PartialSuccess') {
+    return {
+      label: 'Partial',
+      className: 'status-sync--partial',
+      detail: 'Some records refreshed, but the source needs review.',
+    }
+  }
+
+  if (feed.lastSyncCompletedAt) {
+    return {
+      label: 'Current',
+      className: 'status-sync--success',
+      detail: `Last refreshed ${formatRelative(feed.lastSyncCompletedAt)}.`,
+    }
+  }
+
+  if ((feed.lastRecordsFetched ?? 0) > 0) {
+    return {
+      label: 'Snapshot available',
+      className: 'status-sync--success',
+      detail: 'This source is included in the current published snapshot.',
+    }
+  }
+
+  return {
+    label: 'Pending',
+    className: 'status-sync--never',
+    detail: 'No published snapshot has been generated for this source yet.',
+  }
+}
+
+function formatFeedType(type: string) {
+  switch (type) {
+    case 'CdcSocrata':
+      return 'CDC dataset'
+    case 'CdcRss':
+      return 'Public alert feed'
+    case 'NpiRegistry':
+      return 'Provider registry'
+    case 'HrsaHealthCenter':
+      return 'HRSA clinic site directory'
+    case 'HrsaHpsa':
+      return 'HRSA shortage-area dataset'
+    case 'EpaSdwis':
+      return 'EPA drinking water dataset'
+    case 'OpenFda':
+      return 'FDA enforcement feed'
+    default:
+      return type
   }
 }
 
@@ -42,6 +97,8 @@ export function StatusPage() {
 
   const totalAlerts = states.reduce((sum, s) => sum + s.publishedAlertCount, 0)
   const totalResources = states.reduce((sum, s) => sum + s.resourceTotal, 0)
+  const currentFeedCount = status?.feeds.filter((feed) => getFeedStatus(feed).label !== 'Needs attention').length ?? 0
+  const totalFetched = status?.feeds.reduce((sum, feed) => sum + (feed.lastRecordsFetched ?? 0), 0) ?? 0
 
   return (
     <section className="page-frame">
@@ -70,45 +127,53 @@ export function StatusPage() {
         {statusQuery.isLoading ? (
           <p>Loading status...</p>
         ) : status ? (
-          <section className="page-panel">
-            <span className="section-kicker">Feed sync status</span>
-            <strong>Data sources and their latest sync results</strong>
-            <div className="status-table-wrap">
-              <table className="status-table">
-                <thead>
-                  <tr>
-                    <th>Feed</th>
-                    <th>Type</th>
-                    <th>Status</th>
-                    <th>Last sync</th>
-                    <th>Fetched</th>
-                    <th>Created</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {status.feeds.map((feed) => (
-                    <tr key={feed.name}>
-                      <td>
+          <>
+            <section className="page-panel">
+              <span className="section-kicker">Source health</span>
+              <strong>Published data sources in the current snapshot</strong>
+              <div className="page-badges">
+                <span className="page-badge">{status.feeds.length} active feeds</span>
+                <span className="page-badge">{currentFeedCount} available in snapshot</span>
+                <span className="page-badge">{totalFetched.toLocaleString()} records fetched</span>
+              </div>
+            </section>
+
+            <section className="page-panel">
+              <span className="section-kicker">Feed status</span>
+              <strong>Coverage and freshness for each published source</strong>
+              <div className="status-feed-grid">
+                {status.feeds.map((feed) => {
+                  const displayStatus = getFeedStatus(feed)
+
+                  return (
+                    <article className="status-feed-card" key={feed.name}>
+                      <div className="status-feed-card__header">
                         <strong>{feed.name}</strong>
-                        {!feed.isEnabled && <span className="status-badge status-badge--disabled"> disabled</span>}
-                      </td>
-                      <td>{feed.type}</td>
-                      <td>
-                        <span className={`status-badge ${syncStatusClass(feed.lastSyncStatus)}`}>
-                          {feed.lastSyncStatus ?? 'Unknown'}
+                        <span className={`status-badge ${displayStatus.className}`}>
+                          {displayStatus.label}
                         </span>
-                      </td>
-                      <td title={formatDateTime(feed.lastSyncCompletedAt)}>
-                        {formatRelative(feed.lastSyncCompletedAt)}
-                      </td>
-                      <td>{feed.lastRecordsFetched ?? '-'}</td>
-                      <td>{feed.lastRecordsCreated ?? '-'}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </section>
+                      </div>
+                      <span className="status-feed-card__type">{formatFeedType(feed.type)}</span>
+                      <p>{displayStatus.detail}</p>
+                      <p className="status-feed-card__updated">
+                        Last updated: {formatDateTime(feed.lastSyncCompletedAt)}
+                      </p>
+                      <div className="status-feed-card__metrics">
+                        <span className="page-badge">
+                          {(feed.lastRecordsFetched ?? 0).toLocaleString()} fetched
+                        </span>
+                        {feed.lastSyncCompletedAt ? (
+                          <span className="page-badge" title={formatDateTime(feed.lastSyncCompletedAt)}>
+                            {formatRelative(feed.lastSyncCompletedAt)}
+                          </span>
+                        ) : null}
+                      </div>
+                    </article>
+                  )
+                })}
+              </div>
+            </section>
+          </>
         ) : null}
 
         <section className="page-panel">


### PR DESCRIPTION
## What changed
- added normalized Phase 1 backend entities and ingestion for HRSA HPSA and EPA SDWIS
- extended region snapshots and static export with access and environmental safety signals
- surfaced new access and safety summaries on region and state pages
- improved status page feed labeling and last-updated handling

## Why
Phase 1 adds open public datasets for care-access constraints and local water safety without collapsing them into the alert/resource schema, keeping the data model organized and closer to third normal form.

## Impact
Users can now see shortage-area and drinking-water signals in the static UI, and the status page reports clearer feed freshness.

## Validation
- dotnet build src/backend/SniffleReport.Api/SniffleReport.Api.csproj --configuration Release --no-restore
- npm run build
- npm test -- --run src/pages/StateBrowsePage.test.tsx src/pages/RegionalDashboardPage.test.tsx
- bash export.sh